### PR TITLE
Add per-chapter YAML frontmatter to all 209 chapters (C, #19)

### DIFF
--- a/markdown/01-beige/01-what-is-beige.md
+++ b/markdown/01-beige/01-what-is-beige.md
@@ -1,3 +1,15 @@
+---
+id: beige-1
+stage: 1
+chapter: 1
+order: 1
+slug: what-is-beige
+title: "What is Beige?"
+content_type: chapter
+release_day: 0
+media: []
+---
+
 ## What is Beige?
 
 About the automatic, reactionary survival mode upon which civil society is a thin veneer, fantasy author Patrick Rothfuss paints the following scene. For context the narrator was a homeless orphan for years in the crime ridden city of Tarbean:

--- a/markdown/01-beige/02-why-beige-matters-the-physiology-of-safety-and-the-soul-of-s.md
+++ b/markdown/01-beige/02-why-beige-matters-the-physiology-of-safety-and-the-soul-of-s.md
@@ -1,3 +1,15 @@
+---
+id: beige-2
+stage: 1
+chapter: 2
+order: 2
+slug: why-beige-matters-the-physiology-of-safety-and-the-soul-of-s
+title: "Why Beige Matters: The Physiology of Safety and the Soul of Stability"
+content_type: chapter
+release_day: 1
+media: []
+---
+
 ## Why Beige Matters: The Physiology of Safety and the Soul of Stability
 
 Beige is not just a metaphorical stage of development.

--- a/markdown/01-beige/03-the-journaling-prompts-of-beige.md
+++ b/markdown/01-beige/03-the-journaling-prompts-of-beige.md
@@ -1,3 +1,15 @@
+---
+id: beige-3
+stage: 1
+chapter: 3
+order: 3
+slug: the-journaling-prompts-of-beige
+title: "The Journaling Prompts of Beige"
+content_type: chapter
+release_day: 2
+media: []
+---
+
 ## The Journaling Prompts of Beige
 
 To further anchor this learning, Beige invites you into two core journaling practices. Some basic rules first:

--- a/markdown/01-beige/04-the-relationship-to-free-will-at-beige.md
+++ b/markdown/01-beige/04-the-relationship-to-free-will-at-beige.md
@@ -1,3 +1,15 @@
+---
+id: beige-4
+stage: 1
+chapter: 4
+order: 4
+slug: the-relationship-to-free-will-at-beige
+title: "The Relationship to Free Will at Beige"
+content_type: chapter
+release_day: 3
+media: []
+---
+
 ## The Relationship to Free Will at Beige
 
 Let’s get right to it. What is the relationship to Free Will? That’s what this whole course is about after all, isn’t it?

--- a/markdown/01-beige/05-the-vibe-wavelength-of-beige-internalize-do.md
+++ b/markdown/01-beige/05-the-vibe-wavelength-of-beige-internalize-do.md
@@ -1,3 +1,15 @@
+---
+id: beige-5
+stage: 1
+chapter: 5
+order: 5
+slug: the-vibe-wavelength-of-beige-internalize-do
+title: "The Vibe Wavelength of Beige: Internalize (Do)"
+content_type: chapter
+release_day: 4
+media: []
+---
+
 ## The Vibe Wavelength of Beige: Internalize (Do)
 
 This stage also builds on the introduction to the Archetypal Wavelength that you should have picked up from the <a href="https://www.google.com/url?q=https://aptitude.guru/philosophy/archetypal-wavelength&sa=D&source=editors&ust=1764912627500309&usg=AOvVaw2E0uWn4AqXvS3EHHDuBcVy"

--- a/markdown/01-beige/06-the-grounding-protocol-5-4-3-2-1.md
+++ b/markdown/01-beige/06-the-grounding-protocol-5-4-3-2-1.md
@@ -1,3 +1,15 @@
+---
+id: beige-6
+stage: 1
+chapter: 6
+order: 6
+slug: the-grounding-protocol-5-4-3-2-1
+title: "The Grounding Protocol: 5-4-3-2-1"
+content_type: chapter
+release_day: 5
+media: []
+---
+
 ## The Grounding Protocol: 5-4-3-2-1
 
 And when you do feel yourself slipping into that Overdose energy—when your crown chakra swells and you start chasing too many dreams at once—that’s where the first Practice of the path comes in.

--- a/markdown/01-beige/07-the-default-habit-of-beige-take-work-seriously.md
+++ b/markdown/01-beige/07-the-default-habit-of-beige-take-work-seriously.md
@@ -1,3 +1,15 @@
+---
+id: beige-7
+stage: 1
+chapter: 7
+order: 7
+slug: the-default-habit-of-beige-take-work-seriously
+title: "The Default Habit of Beige: Take Work Seriously"
+content_type: chapter
+release_day: 6
+media: []
+---
+
 ## The Default Habit of Beige: Take Work Seriously
 
 To begin correcting these root-level imbalances, we have the recommendation slash option to anchor in a Habit that is essential to physical security: Taking Work Seriously.

--- a/markdown/01-beige/08-energy-scaffolding.md
+++ b/markdown/01-beige/08-energy-scaffolding.md
@@ -1,3 +1,15 @@
+---
+id: beige-8
+stage: 1
+chapter: 8
+order: 8
+slug: energy-scaffolding
+title: "Energy Scaffolding"
+content_type: chapter
+release_day: 7
+media: []
+---
+
 ## Energy Scaffolding
 
 If you aren’t called to stick with the default Habits, your APTITUDE journey hinges on the process of Energy Scaffolding: the sacred art of building your life one Habit at a time. Every 21 days, you’ll add a new behavior to your stack—a Habit that gives more energy back to you than it takes to engage with it. You choose habits that feed you.

--- a/markdown/01-beige/09-how-to-perform-energy-scaffolding.md
+++ b/markdown/01-beige/09-how-to-perform-energy-scaffolding.md
@@ -1,3 +1,15 @@
+---
+id: beige-9
+stage: 1
+chapter: 9
+order: 9
+slug: how-to-perform-energy-scaffolding
+title: "How to Perform Energy Scaffolding"
+content_type: chapter
+release_day: 8
+media: []
+---
+
 ## How to Perform Energy Scaffolding
 
 Step 1: Open a spreadsheet. Make four columns:

--- a/markdown/01-beige/10-the-four-gates-of-habit-alchemy.md
+++ b/markdown/01-beige/10-the-four-gates-of-habit-alchemy.md
@@ -1,3 +1,15 @@
+---
+id: beige-10
+stage: 1
+chapter: 10
+order: 10
+slug: the-four-gates-of-habit-alchemy
+title: "The Four Gates of Habit Alchemy"
+content_type: chapter
+release_day: 9
+media: []
+---
+
 ## The Four Gates of Habit Alchemy
 
 An essential pocket summary of James Clears’ philosophy from Atomic Habits.

--- a/markdown/01-beige/11-internalize-do.md
+++ b/markdown/01-beige/11-internalize-do.md
@@ -1,3 +1,15 @@
+---
+id: beige-11
+stage: 1
+chapter: 11
+order: 11
+slug: internalize-do
+title: "“INTERNALIZE (Do)”"
+content_type: chapter
+release_day: 10
+media: []
+---
+
 ## “INTERNALIZE (Do)”
 
 Approaching the Archetypal Wavelength from the perspective of Beige, one option is to observe and improve the energetic rhythm of building habits. In this Agentic Yes-And-Ness Aspect of Whole Adepthood, the Wavelength can be thought of as the core behaviors that take care of your meat.

--- a/markdown/01-beige/12-in-summary.md
+++ b/markdown/01-beige/12-in-summary.md
@@ -1,3 +1,15 @@
+---
+id: beige-12
+stage: 1
+chapter: 12
+order: 12
+slug: in-summary
+title: "In Summary"
+content_type: chapter
+release_day: 11
+media: []
+---
+
 ## In Summary
 
 This expression of the Archetypal Wavelength shows us the trap of trying to “change everything at once” and the magic of letting momentum accrue through consistency. Energy Scaffolding isn't about burning bright and fast—it's about building energy slowly, habit by habit, the tortoise whose consistent, temperate strategy wins the race.

--- a/markdown/01-beige/13-the-sacred-highand-the-temptation-to-stay-there-forever.md
+++ b/markdown/01-beige/13-the-sacred-highand-the-temptation-to-stay-there-forever.md
@@ -1,3 +1,15 @@
+---
+id: beige-13
+stage: 1
+chapter: 13
+order: 13
+slug: the-sacred-highand-the-temptation-to-stay-there-forever
+title: "The Sacred High—and the Temptation to Stay There Forever"
+content_type: chapter
+release_day: 12
+media: []
+---
+
 ## The Sacred High—and the Temptation to Stay There Forever
 
 Sometimes it truly starts innocently. Perhaps I’ve been diligent. My habit stack is locked in. I’m starting to vibe in that sweet Peak energy. But then, the Overdose. Thriving rather than persisting with Diligence.

--- a/markdown/01-beige/14-when-you-dont-ground-you-float-into-disconnection.md
+++ b/markdown/01-beige/14-when-you-dont-ground-you-float-into-disconnection.md
@@ -1,3 +1,15 @@
+---
+id: beige-14
+stage: 1
+chapter: 14
+order: 14
+slug: when-you-dont-ground-you-float-into-disconnection
+title: "When You Don't Ground, You Float Into Disconnection"
+content_type: chapter
+release_day: 13
+media: []
+---
+
 ## When You Don't Ground, You Float Into Disconnection
 
 The Overconsumption Offramp leads to a high-frequency feedback loop. I have learned to recognize the feeling of being lifted too far from my body. Synchronicities abound at first, but then I get to looking for them too intensely. I end up with the psychotic obsessions with coincidence that the psychiatrists call delusions of reference.

--- a/markdown/01-beige/15-and-then-the-dangerous-temptation-to-repeat.md
+++ b/markdown/01-beige/15-and-then-the-dangerous-temptation-to-repeat.md
@@ -1,3 +1,15 @@
+---
+id: beige-15
+stage: 1
+chapter: 15
+order: 15
+slug: and-then-the-dangerous-temptation-to-repeat
+title: "And then… the dangerous temptation to repeat"
+content_type: chapter
+release_day: 14
+media: []
+---
+
 ## And then… the dangerous temptation to repeat
 
 Eventually, something cracks open again. You get a bit of your mojo back. You taste the memory of Thriving. And you say:

--- a/markdown/01-beige/16-the-5-4-3-2-1-technique-your-root-chakra-reset.md
+++ b/markdown/01-beige/16-the-5-4-3-2-1-technique-your-root-chakra-reset.md
@@ -1,3 +1,15 @@
+---
+id: beige-16
+stage: 1
+chapter: 16
+order: 16
+slug: the-5-4-3-2-1-technique-your-root-chakra-reset
+title: "The 5-4-3-2-1 Technique (Your Root Chakra Reset)"
+content_type: chapter
+release_day: 15
+media: []
+---
+
 ## The 5-4-3-2-1 Technique (Your Root Chakra Reset)
 
 When your crown chakra starts inflating and you feel your feet leaving the ground—when your to-do list gets wild and your dreams start tasting like mania—pause and drop into this:

--- a/markdown/01-beige/17-alternative-practice-options.md
+++ b/markdown/01-beige/17-alternative-practice-options.md
@@ -1,3 +1,15 @@
+---
+id: beige-17
+stage: 1
+chapter: 17
+order: 17
+slug: alternative-practice-options
+title: "Alternative Practice Options"
+content_type: chapter
+release_day: 16
+media: []
+---
+
 ## Alternative Practice Options
 
 Although the 5-4-3-2-1 technique is like a great bit of Pratyahara (or yogic “turning inward”), many people find it hard to remember the order or keep the numbers straight.

--- a/markdown/01-beige/18-a-note-on-beige-practice.md
+++ b/markdown/01-beige/18-a-note-on-beige-practice.md
@@ -1,3 +1,15 @@
+---
+id: beige-18
+stage: 1
+chapter: 18
+order: 18
+slug: a-note-on-beige-practice
+title: "A Note on Beige Practice"
+content_type: chapter
+release_day: 17
+media: []
+---
+
 ## A Note on Beige Practice
 
 Play around with different techniques to find the one that suits you. Figure out what brings you back into your body.

--- a/markdown/02-purple/01-what-is-purple.md
+++ b/markdown/02-purple/01-what-is-purple.md
@@ -1,3 +1,15 @@
+---
+id: purple-1
+stage: 2
+chapter: 1
+order: 1
+slug: what-is-purple
+title: "What is Purple?"
+content_type: chapter
+release_day: 0
+media: []
+---
+
 ## What is Purple?
 
 Purple is the second Stage of APTITUDE, and the second half of the first polarity: Yes-And-Ness. While Beige is concerned with Agency—the “And” that gives us the will to act, to move, to survive—Purple brings its sacred complement: Receptivity. It is the “Yes.”

--- a/markdown/02-purple/02-the-mood-of-purple-yes-and-nessreceptivity.md
+++ b/markdown/02-purple/02-the-mood-of-purple-yes-and-nessreceptivity.md
@@ -1,3 +1,15 @@
+---
+id: purple-2
+stage: 2
+chapter: 2
+order: 2
+slug: the-mood-of-purple-yes-and-nessreceptivity
+title: "The Mood of Purple: Yes-And-Ness—Receptivity"
+content_type: chapter
+release_day: 1
+media: []
+---
+
 ## The Mood of Purple: Yes-And-Ness—Receptivity
 
 The Mood of Purple is Yes-And-Ness—Receptivity.

--- a/markdown/02-purple/03-the-journaling-prompts-of-purple.md
+++ b/markdown/02-purple/03-the-journaling-prompts-of-purple.md
@@ -1,3 +1,15 @@
+---
+id: purple-3
+stage: 2
+chapter: 3
+order: 3
+slug: the-journaling-prompts-of-purple
+title: "The Journaling Prompts of Purple"
+content_type: chapter
+release_day: 2
+media: []
+---
+
 ## The Journaling Prompts of Purple
 
 To further embody the energy of Purple and the Mood of Receptivity, this Stage invites you into journaling practices designed not to assert or control, but to listen. To feel into your life. To receive its messages. These prompts are not meant to extract insight through force of will, but to open a channel for it. Your role here is not to “figure it out,” but to soften enough that something true might rise up on its own.

--- a/markdown/02-purple/04-the-relationship-to-free-will-at-purple-archetype-embodier.md
+++ b/markdown/02-purple/04-the-relationship-to-free-will-at-purple-archetype-embodier.md
@@ -1,3 +1,15 @@
+---
+id: purple-4
+stage: 2
+chapter: 4
+order: 4
+slug: the-relationship-to-free-will-at-purple-archetype-embodier
+title: "The Relationship to Free Will at Purple: Archetype Embodier"
+content_type: chapter
+release_day: 3
+media: []
+---
+
 ## The Relationship to Free Will at Purple: Archetype Embodier
 
 Let’s get right to it. What is the relationship to Free Will at Purple?

--- a/markdown/02-purple/05-the-vibe-wavelength-of-purple-internalize-feel.md
+++ b/markdown/02-purple/05-the-vibe-wavelength-of-purple-internalize-feel.md
@@ -1,3 +1,15 @@
+---
+id: purple-5
+stage: 2
+chapter: 5
+order: 5
+slug: the-vibe-wavelength-of-purple-internalize-feel
+title: "The Vibe Wavelength of Purple: Internalize (Feel)"
+content_type: chapter
+release_day: 4
+media: []
+---
+
 ## The Vibe Wavelength of Purple: Internalize (Feel)
 
 ![](../markdown/images/images/image3.png)

--- a/markdown/02-purple/06-the-practice-of-purple-a-daily-tarot-draw.md
+++ b/markdown/02-purple/06-the-practice-of-purple-a-daily-tarot-draw.md
@@ -1,3 +1,15 @@
+---
+id: purple-6
+stage: 2
+chapter: 6
+order: 6
+slug: the-practice-of-purple-a-daily-tarot-draw
+title: "The Practice of Purple: A Daily Tarot Draw"
+content_type: chapter
+release_day: 5
+media: []
+---
+
 ## The Practice of Purple: A Daily Tarot Draw
 
 ![](../markdown/images/images/image6.png)

--- a/markdown/02-purple/07-alternative-practice-examples-i-ching-traffic-lights-bibliom.md
+++ b/markdown/02-purple/07-alternative-practice-examples-i-ching-traffic-lights-bibliom.md
@@ -1,3 +1,15 @@
+---
+id: purple-7
+stage: 2
+chapter: 7
+order: 7
+slug: alternative-practice-examples-i-ching-traffic-lights-bibliom
+title: "Alternative Practice Examples: I-Ching, Traffic Lights, Bibliomancy, Synchronicity"
+content_type: chapter
+release_day: 6
+media: []
+---
+
 ## Alternative Practice Examples: I-Ching, Traffic Lights, Bibliomancy, Synchronicity
 
 While the Daily Tarot Draw is the recommended Practice for Purple, APTITUDE is not dogma—it’s a compass, not a commandment. If Tarot doesn’t vibe with you, or if you feel called to experiment with other forms of symbolic receptivity, you’re absolutely encouraged to do so. This is your path. The practice is not sacred. The attunement is.

--- a/markdown/02-purple/08-the-default-habit-of-purple-vitamins-probiotics-and-water.md
+++ b/markdown/02-purple/08-the-default-habit-of-purple-vitamins-probiotics-and-water.md
@@ -1,3 +1,15 @@
+---
+id: purple-8
+stage: 2
+chapter: 8
+order: 8
+slug: the-default-habit-of-purple-vitamins-probiotics-and-water
+title: "The Default Habit of Purple: Vitamins, Probiotics, and Water"
+content_type: chapter
+release_day: 7
+media: []
+---
+
 ## The Default Habit of Purple: Vitamins, Probiotics, and Water
 
 To begin correcting imbalances in Receptivity—the central quality of Purple—we introduce a Habit that is simple, low-effort, and surprisingly profound: Take your vitamins, drink your water, and support your gut with a probiotic.

--- a/markdown/02-purple/09-yes-and-ness-a-balance-between-radical-agency-and-radical-ac.md
+++ b/markdown/02-purple/09-yes-and-ness-a-balance-between-radical-agency-and-radical-ac.md
@@ -1,3 +1,15 @@
+---
+id: purple-9
+stage: 2
+chapter: 9
+order: 9
+slug: yes-and-ness-a-balance-between-radical-agency-and-radical-ac
+title: "Yes-And-Ness: A balance between Radical Agency and Radical Acceptance"
+content_type: chapter
+release_day: 8
+media: []
+---
+
 ## Yes-And-Ness: A balance between Radical Agency and Radical Acceptance
 
 “Yes-and-ness” is a term I coined to capture the delicate, alchemical balance between two spiritual instincts that have long pulled at me: the Eastern embrace of Radical Acceptance and the Western drive for Radical Agency.

--- a/markdown/02-purple/10-archetypal-gender-masculine-feminine-and-baphomet.md
+++ b/markdown/02-purple/10-archetypal-gender-masculine-feminine-and-baphomet.md
@@ -1,3 +1,15 @@
+---
+id: purple-10
+stage: 2
+chapter: 10
+order: 10
+slug: archetypal-gender-masculine-feminine-and-baphomet
+title: "Archetypal Gender: Masculine, Feminine, and Baphomet"
+content_type: chapter
+release_day: 9
+media: []
+---
+
 ## Archetypal Gender: Masculine, Feminine, and Baphomet
 
 ![](../markdown/images/images/image1.png)

--- a/markdown/02-purple/11-purples-gift-welcoming-in-beauty.md
+++ b/markdown/02-purple/11-purples-gift-welcoming-in-beauty.md
@@ -1,3 +1,15 @@
+---
+id: purple-11
+stage: 2
+chapter: 11
+order: 11
+slug: purples-gift-welcoming-in-beauty
+title: "Purple’s Gift: Welcoming in Beauty"
+content_type: chapter
+release_day: 10
+media: []
+---
+
 ## Purple’s Gift: Welcoming in Beauty
 
 The gift of Purple is the return to Receptivity—a gentle reorientation from striving to sensing, from control to communion. When the Adept softens into this phase of the spiral, something exquisite becomes possible: the world starts to shimmer. Not because it has changed, but because you have. Purple’s core gift is the ability to welcome in beauty—not by chasing it, but by learning how to let it in.

--- a/markdown/02-purple/12-purples-shadow-delusions-of-reference-and-magical-thinking.md
+++ b/markdown/02-purple/12-purples-shadow-delusions-of-reference-and-magical-thinking.md
@@ -1,3 +1,15 @@
+---
+id: purple-12
+stage: 2
+chapter: 12
+order: 12
+slug: purples-shadow-delusions-of-reference-and-magical-thinking
+title: "Purple’s Shadow: Delusions of Reference and Magical Thinking"
+content_type: chapter
+release_day: 11
+media: []
+---
+
 ## Purple’s Shadow: Delusions of Reference and Magical Thinking
 
 Every light casts a shadow, and in Purple, the radiant gift of Receptivity can tip into something overwhelming, seductive, and ultimately destabilizing. When this stage becomes pathological, it’s not because it lacks power—but because its power is ungrounded. The very sensitivity that allows you to hear whispers from the universe can, without anchoring, become a cacophony of ghosts.

--- a/markdown/02-purple/13-internalize-feel.md
+++ b/markdown/02-purple/13-internalize-feel.md
@@ -1,3 +1,15 @@
+---
+id: purple-13
+stage: 2
+chapter: 13
+order: 13
+slug: internalize-feel
+title: "“INTERNALIZE (Feel)”"
+content_type: chapter
+release_day: 12
+media: []
+---
+
 ## “INTERNALIZE (Feel)”
 
 Approaching the Archetypal Wavelength from the perspective of Purple means shifting from Doing to Feeling. This is the Internalize (Feel)

--- a/markdown/02-purple/14-pranasynthesis-as-the-cure-for-depression.md
+++ b/markdown/02-purple/14-pranasynthesis-as-the-cure-for-depression.md
@@ -1,3 +1,15 @@
+---
+id: purple-14
+stage: 2
+chapter: 14
+order: 14
+slug: pranasynthesis-as-the-cure-for-depression
+title: "“Pranasynthesis” as the Cure for Depression"
+content_type: chapter
+release_day: 13
+media: []
+---
+
 ## “Pranasynthesis” as the Cure for Depression
 
 There are times when nothing works. The practices stall. The joy is gone. Even rest doesn’t restore, and everything once charged with beauty becomes flat, gray, muffled like a song underwater. This is the Diminishing and Bottoming Out stretch of the Feel Wavelength when traversed without skill—when we resist, when we compare, when we collapse into a sense of terminal brokenness. It is also what much of the modern world simply calls depression.

--- a/markdown/02-purple/15-tarot-in-the-foxhole-inviting-in-source-via-divination.md
+++ b/markdown/02-purple/15-tarot-in-the-foxhole-inviting-in-source-via-divination.md
@@ -1,3 +1,15 @@
+---
+id: purple-15
+stage: 2
+chapter: 15
+order: 15
+slug: tarot-in-the-foxhole-inviting-in-source-via-divination
+title: "Tarot in the Foxhole: Inviting in Source via Divination"
+content_type: chapter
+release_day: 14
+media: []
+---
+
 ## Tarot in the Foxhole: Inviting in Source via Divination
 
 There’s a moment, in the low fog of depression, when your body has finally been tended to—enough water has touched your cells, your blood sugar has stabilized, you’re no longer physically clenched or freezing. The most basic Beige needs have been met, and yet, the light hasn’t returned. You’re functional, but barely animate. The world still feels a few layers removed.

--- a/markdown/03-red/01-what-is-red.md
+++ b/markdown/03-red/01-what-is-red.md
@@ -1,3 +1,15 @@
+---
+id: red-1
+stage: 3
+chapter: 1
+order: 1
+slug: what-is-red
+title: "What is Red?"
+content_type: chapter
+release_day: 0
+media: []
+---
+
 ## What is Red?
 
 Welcome to Red, the third stage in your conscious traversal of the spiral. It’s not the first time you’ve been here, of course—but it may be the first time you’ve seen it clearly. The first time you’ve recognized this mode of being not as your default lens, but as a developmental station—something you can observe, understand, and integrate. That move, from subject to object, is where Free Will begins.

--- a/markdown/03-red/02-the-mood-of-red-self-love-and-power.md
+++ b/markdown/03-red/02-the-mood-of-red-self-love-and-power.md
@@ -1,3 +1,15 @@
+---
+id: red-2
+stage: 3
+chapter: 2
+order: 2
+slug: the-mood-of-red-self-love-and-power
+title: "The Mood of Red: Self-Love and Power"
+content_type: chapter
+release_day: 1
+media: []
+---
+
 ## The Mood of Red: Self-Love and Power
 
 Red falls within the second category of APTITUDE:

--- a/markdown/03-red/03-the-journaling-prompts-of-red.md
+++ b/markdown/03-red/03-the-journaling-prompts-of-red.md
@@ -1,3 +1,15 @@
+---
+id: red-3
+stage: 3
+chapter: 3
+order: 3
+slug: the-journaling-prompts-of-red
+title: "The Journaling Prompts of Red"
+content_type: chapter
+release_day: 2
+media: []
+---
+
 ## The Journaling Prompts of Red
 
 Before we dive into the Red journaling prompts, let’s recall what we introduced back in Beige. Journaling, in the APTITUDE sense, isn’t some precious, self-important artform. It’s a tool. A form of embodied, verbal meditation. The practice is simple but potent: set a timer for fifteen minutes, pick up a pen (not a pencil—no erasing), and don’t stop moving your hand. If you stall out, write “I don’t know what to write” until something else comes.

--- a/markdown/03-red/04-the-relationship-to-free-will-at-red-dominator.md
+++ b/markdown/03-red/04-the-relationship-to-free-will-at-red-dominator.md
@@ -1,3 +1,15 @@
+---
+id: red-4
+stage: 3
+chapter: 4
+order: 4
+slug: the-relationship-to-free-will-at-red-dominator
+title: "The Relationship to Free Will at Red: Dominator"
+content_type: chapter
+release_day: 3
+media: []
+---
+
 ## The Relationship to Free Will at Red: Dominator
 
 Let’s clarify something right away: The Dominator is not the goal.

--- a/markdown/03-red/05-the-vibe-wavelength-of-red-externalize-do.md
+++ b/markdown/03-red/05-the-vibe-wavelength-of-red-externalize-do.md
@@ -1,3 +1,15 @@
+---
+id: red-5
+stage: 3
+chapter: 5
+order: 5
+slug: the-vibe-wavelength-of-red-externalize-do
+title: "The Vibe Wavelength of Red: Externalize (Do)"
+content_type: chapter
+release_day: 4
+media: []
+---
+
 ## The Vibe Wavelength of Red: Externalize (Do)
 
 This stage continues our exploration of the Archetypal Wavelength—APTITUDE’s core model for understanding how all energy moves in cycles. If you haven’t yet read the foundational Philosophy material, now’s a great time to check it out. It’s the ground we build on.

--- a/markdown/03-red/06-the-practice-of-red-paced-breathing.md
+++ b/markdown/03-red/06-the-practice-of-red-paced-breathing.md
@@ -1,3 +1,15 @@
+---
+id: red-6
+stage: 3
+chapter: 6
+order: 6
+slug: the-practice-of-red-paced-breathing
+title: "The Practice of Red: Paced Breathing"
+content_type: chapter
+release_day: 5
+media: []
+---
+
 ## The Practice of Red: Paced Breathing
 
 If Beige gave us grounding, and Purple gave us resonance, Red gives us spine. The Practice of Red is about standing in your selfhood—not with force or performance, but with embodied confidence. And there’s no better place to build that kind of strength than in your breath.

--- a/markdown/03-red/07-alternatives-for-red-practice.md
+++ b/markdown/03-red/07-alternatives-for-red-practice.md
@@ -1,3 +1,15 @@
+---
+id: red-7
+stage: 3
+chapter: 7
+order: 7
+slug: alternatives-for-red-practice
+title: "Alternatives for Red Practice"
+content_type: chapter
+release_day: 6
+media: []
+---
+
 ## Alternatives for Red Practice
 
 Not vibing with Paced Breathing? That’s okay.

--- a/markdown/03-red/08-the-default-habit-of-red-looking-at-alcoholintoxicants.md
+++ b/markdown/03-red/08-the-default-habit-of-red-looking-at-alcoholintoxicants.md
@@ -1,3 +1,15 @@
+---
+id: red-8
+stage: 3
+chapter: 8
+order: 8
+slug: the-default-habit-of-red-looking-at-alcoholintoxicants
+title: "The Default Habit of Red: Looking at Alcohol/Intoxicants"
+content_type: chapter
+release_day: 7
+media: []
+---
+
 ## The Default Habit of Red: Looking at Alcohol/Intoxicants
 
 Every stage of APTITUDE comes with a Default Habit—a behavior that arises unconsciously when the energetic tone of that stage is dominant but unexamined. For Red, that habit is intoxication.

--- a/markdown/03-red/09-reds-divine-gender-back-to-the-masculine-i-self-expressing.md
+++ b/markdown/03-red/09-reds-divine-gender-back-to-the-masculine-i-self-expressing.md
@@ -1,3 +1,15 @@
+---
+id: red-9
+stage: 3
+chapter: 9
+order: 9
+slug: reds-divine-gender-back-to-the-masculine-i-self-expressing
+title: "Red’s Divine Gender: Back to the Masculine, I, Self-Expressing"
+content_type: chapter
+release_day: 8
+media: []
+---
+
 ## Red’s Divine Gender: Back to the Masculine, I, Self-Expressing
 
 Purple drifted on shared feeling; Red snaps into personal direction. The current swivels from we to I, from moon-pull to sun-push. In APTITUDE’s color wheel, every cool, receptive stage is followed by a warm, projective one. Red is the first warm return, carrying the signature of the Divine Masculine—the impulse to step forward, speak clearly, claim ground.

--- a/markdown/03-red/10-reframing-red-self-love-rather-than-power.md
+++ b/markdown/03-red/10-reframing-red-self-love-rather-than-power.md
@@ -1,3 +1,15 @@
+---
+id: red-10
+stage: 3
+chapter: 10
+order: 10
+slug: reframing-red-self-love-rather-than-power
+title: "Reframing Red: Self-Love Rather than Power"
+content_type: chapter
+release_day: 9
+media: []
+---
+
 ## Reframing Red: Self-Love Rather than Power
 
 Red gets saddled with the warlord costume—gang leaders staking turf, fascists barking slogans, bullies prowling hallways. Spiral Dynamics stamps that image into the collective imagination, and it tracks: raw will forcing reality to bend. Yet spend time with anyone stuck there and you’ll find the fire is fueled by something colder—shame. They fear they’re unworthy, so they make others kneel. It’s a ransom note to the world that reads, “Tell me I matter or I’ll keep swinging.”

--- a/markdown/03-red/11-reds-shadow-power-over-vs-power-with.md
+++ b/markdown/03-red/11-reds-shadow-power-over-vs-power-with.md
@@ -1,3 +1,15 @@
+---
+id: red-11
+stage: 3
+chapter: 11
+order: 11
+slug: reds-shadow-power-over-vs-power-with
+title: "Red’s Shadow: Power-Over vs Power-With"
+content_type: chapter
+release_day: 10
+media: []
+---
+
 ## Red’s Shadow: Power-Over vs Power-With
 
 ### The Dangers of Red Narcissism

--- a/markdown/03-red/12-externalize-do.md
+++ b/markdown/03-red/12-externalize-do.md
@@ -1,3 +1,15 @@
+---
+id: red-12
+stage: 3
+chapter: 12
+order: 12
+slug: externalize-do
+title: "“EXTERNALIZE (Do)”"
+content_type: chapter
+release_day: 11
+media: []
+---
+
 ## “EXTERNALIZE (Do)”
 
 ![](../markdown/images/images/image1.png)

--- a/markdown/03-red/13-the-archetypal-wavelength-reveals-everything-is-a-practice.md
+++ b/markdown/03-red/13-the-archetypal-wavelength-reveals-everything-is-a-practice.md
@@ -1,3 +1,15 @@
+---
+id: red-13
+stage: 3
+chapter: 13
+order: 13
+slug: the-archetypal-wavelength-reveals-everything-is-a-practice
+title: "The Archetypal Wavelength Reveals Everything is a Practice"
+content_type: chapter
+release_day: 12
+media: []
+---
+
 ## The Archetypal Wavelength Reveals Everything is a Practice
 
 One of the most powerful realizations of Red—and of APTITUDE more broadly—is that everything is a practice. The ten minutes you spend each day with your hand on your belly, breathing into your solar plexus, isn't separate from "real life." It's a microcosm of it. A training ground. A laboratory where you learn to notice the Wavelength in real time and make different choices.

--- a/markdown/03-red/14-practicing-confidence-off-the-cushion.md
+++ b/markdown/03-red/14-practicing-confidence-off-the-cushion.md
@@ -1,3 +1,15 @@
+---
+id: red-14
+stage: 3
+chapter: 14
+order: 14
+slug: practicing-confidence-off-the-cushion
+title: "Practicing Confidence Off the Cushion"
+content_type: chapter
+release_day: 13
+media: []
+---
+
 ## Practicing Confidence Off the Cushion
 
 The real test of Red isn't what happens during your ten-minute practice. It's what happens the other 23 hours and 50 minutes of the day. Can you carry the fire you've cultivated on the cushion into your lived experience? Can you embody confidence when your boss questions your judgment, when your partner criticizes your tone, when your own inner voice whispers that you're a fraud?

--- a/markdown/04-blue/01-what-is-blue.md
+++ b/markdown/04-blue/01-what-is-blue.md
@@ -1,3 +1,15 @@
+---
+id: blue-1
+stage: 4
+chapter: 1
+order: 1
+slug: what-is-blue
+title: "What is Blue?"
+content_type: chapter
+release_day: 0
+media: []
+---
+
 ## What is Blue?
 
 Welcome to Blue—the fourth stage of APTITUDE and the second expression of Love. If Red taught you to love yourself fiercely, to claim your power and protect your boundaries, Blue teaches you to extend that love outward. To the people around you. To the communities you belong to. To the web of relationships that hold you and ask something of you in return.

--- a/markdown/04-blue/02-the-mood-of-blue-lovecommunity-love.md
+++ b/markdown/04-blue/02-the-mood-of-blue-lovecommunity-love.md
@@ -1,3 +1,15 @@
+---
+id: blue-2
+stage: 4
+chapter: 2
+order: 2
+slug: the-mood-of-blue-lovecommunity-love
+title: "The Mood of Blue: Love—Community Love"
+content_type: chapter
+release_day: 1
+media: []
+---
+
 ## The Mood of Blue: Love—Community Love
 
 Blue falls within the second category of APTITUDE: **Love**. If Yes-And-Ness (Beige and Purple) taught you to trust yourself and your intuition, Love is where you learn to extend that trust outward. To open your heart not just to yourself, but to others.

--- a/markdown/04-blue/03-the-journaling-prompts-of-blue.md
+++ b/markdown/04-blue/03-the-journaling-prompts-of-blue.md
@@ -1,3 +1,15 @@
+---
+id: blue-3
+stage: 4
+chapter: 3
+order: 3
+slug: the-journaling-prompts-of-blue
+title: "The Journaling Prompts of Blue"
+content_type: chapter
+release_day: 2
+media: []
+---
+
 ## The Journaling Prompts of Blue
 
 Blue is the stage of relational reflection. The journaling prompts here are designed to help you examine your patterns in relationship—to yourself, to others, to the systems and communities you belong to. They're diagnostic. They're honest. And sometimes, they're uncomfortable.

--- a/markdown/04-blue/04-the-relationship-to-free-will-at-blue-victim.md
+++ b/markdown/04-blue/04-the-relationship-to-free-will-at-blue-victim.md
@@ -1,3 +1,15 @@
+---
+id: blue-4
+stage: 4
+chapter: 4
+order: 4
+slug: the-relationship-to-free-will-at-blue-victim
+title: "The Relationship to Free Will at Blue: Victim"
+content_type: chapter
+release_day: 3
+media: []
+---
+
 ## The Relationship to Free Will at Blue: Victim
 
 At Blue, the relationship to Free Will gets complicated—and painful.

--- a/markdown/04-blue/05-the-vibe-wavelength-of-blue-express-feel.md
+++ b/markdown/04-blue/05-the-vibe-wavelength-of-blue-express-feel.md
@@ -1,3 +1,15 @@
+---
+id: blue-5
+stage: 4
+chapter: 5
+order: 5
+slug: the-vibe-wavelength-of-blue-express-feel
+title: "The Vibe Wavelength of Blue: Express (Feel)"
+content_type: chapter
+release_day: 4
+media: []
+---
+
 ## The Vibe Wavelength of Blue: Express (Feel)
 
 Blue introduces the second Mode in the APTITUDE framework: **Express**. Where Inhabit (Beige, Purple) was about building your own foundation and internal coherence, Express is about *externalizing*. Broadcasting. Sharing what's inside of you with the world.

--- a/markdown/04-blue/06-the-practice-of-blue-metta-meditation.md
+++ b/markdown/04-blue/06-the-practice-of-blue-metta-meditation.md
@@ -1,3 +1,15 @@
+---
+id: blue-6
+stage: 4
+chapter: 6
+order: 6
+slug: the-practice-of-blue-metta-meditation
+title: "The Practice of Blue: Metta Meditation"
+content_type: chapter
+release_day: 5
+media: []
+---
+
 ## The Practice of Blue: Metta Meditation
 
 If Purple was 5 minutes and Red was 10, Blue asks for **15 minutes of daily Metta meditation**—also known as loving-kindness practice. This is the foundational heart-opening practice of Buddhism, and it's *perfectly* suited to Blue's work: training your nervous system to extend love, first to yourself, then to others, then to the entire world.

--- a/markdown/04-blue/07-alternatives-for-blue-practice.md
+++ b/markdown/04-blue/07-alternatives-for-blue-practice.md
@@ -1,3 +1,15 @@
+---
+id: blue-7
+stage: 4
+chapter: 7
+order: 7
+slug: alternatives-for-blue-practice
+title: "Alternatives for Blue Practice"
+content_type: chapter
+release_day: 6
+media: []
+---
+
 ## Alternatives for Blue Practice
 
 Not everyone connects with Metta, especially at first. If the phrases feel empty or forced, or if you have trauma around the concept of "loving-kindness," there are other practices that cultivate the same Blue energies—relational warmth, empathic attunement, heart-opening vulnerability.

--- a/markdown/04-blue/08-the-default-habit-of-blue-looking-at-alcoholintoxicants.md
+++ b/markdown/04-blue/08-the-default-habit-of-blue-looking-at-alcoholintoxicants.md
@@ -1,3 +1,15 @@
+---
+id: blue-8
+stage: 4
+chapter: 8
+order: 8
+slug: the-default-habit-of-blue-looking-at-alcoholintoxicants
+title: "The Default Habit of Blue: Looking at Alcohol/Intoxicants"
+content_type: chapter
+release_day: 7
+media: []
+---
+
 ## The Default Habit of Blue: Looking at Alcohol/Intoxicants
 
 Every stage has a default habit—a behavior that either supports or undermines the work. For Blue, the habit is: **Looking at Alcohol/Intoxicants**.

--- a/markdown/04-blue/09-blues-divine-gender-divine-femininewe-self-sacrificing.md
+++ b/markdown/04-blue/09-blues-divine-gender-divine-femininewe-self-sacrificing.md
@@ -1,3 +1,15 @@
+---
+id: blue-9
+stage: 4
+chapter: 9
+order: 9
+slug: blues-divine-gender-divine-femininewe-self-sacrificing
+title: "Blue's Divine Gender: Divine Feminine—We, Self-Sacrificing"
+content_type: chapter
+release_day: 8
+media: []
+---
+
 ## Blue's Divine Gender: Divine Feminine—We, Self-Sacrificing
 
 Blue swings back to the **Divine Feminine**—the archetypal force of receptivity, relationality, and care. Where Red was the Divine Masculine (assertive, individualistic, self-expressing), Blue is the Divine Feminine (attuned, collective, self-sacrificing).

--- a/markdown/04-blue/10-yes-and-ness-love-understanding-and-freedom-the-broader-aspe.md
+++ b/markdown/04-blue/10-yes-and-ness-love-understanding-and-freedom-the-broader-aspe.md
@@ -1,3 +1,15 @@
+---
+id: blue-10
+stage: 4
+chapter: 10
+order: 10
+slug: yes-and-ness-love-understanding-and-freedom-the-broader-aspe
+title: "Yes-And-Ness, Love, Understanding, and Freedom: The Broader \"Aspect Categories\" of APTITUDE"
+content_type: chapter
+release_day: 9
+media: []
+---
+
 ## Yes-And-Ness, Love, Understanding, and Freedom: The Broader "Aspect Categories" of APTITUDE
 
 Let's zoom out for a moment and look at the structure of APTITUDE as a whole. The ten stages are organized into four **Aspect Categories**:

--- a/markdown/04-blue/11-blues-gift-from-conformity-to-community.md
+++ b/markdown/04-blue/11-blues-gift-from-conformity-to-community.md
@@ -1,3 +1,15 @@
+---
+id: blue-11
+stage: 4
+chapter: 11
+order: 11
+slug: blues-gift-from-conformity-to-community
+title: "Blue's Gift: From Conformity to Community"
+content_type: chapter
+release_day: 10
+media: []
+---
+
 ## Blue's Gift: From Conformity to Community
 
 The deepest gift of Blue is the recognition that **belonging is not the same as conformity**.

--- a/markdown/04-blue/12-blues-shadow-the-drama-triangle-victim-villain-savior.md
+++ b/markdown/04-blue/12-blues-shadow-the-drama-triangle-victim-villain-savior.md
@@ -1,3 +1,15 @@
+---
+id: blue-12
+stage: 4
+chapter: 12
+order: 12
+slug: blues-shadow-the-drama-triangle-victim-villain-savior
+title: "Blue's Shadow: The Drama Triangle (Victim, Villain, Savior)"
+content_type: chapter
+release_day: 11
+media: []
+---
+
 ## Blue's Shadow: The Drama Triangle (Victim, Villain, Savior)
 
 Every light casts a shadow. And Blue's shadow is one of the most insidious, because it *looks* like love but *feels* like poison.

--- a/markdown/04-blue/13-express-feelfull-6-phase-wavelength-breakdown.md
+++ b/markdown/04-blue/13-express-feelfull-6-phase-wavelength-breakdown.md
@@ -1,3 +1,15 @@
+---
+id: blue-13
+stage: 4
+chapter: 13
+order: 13
+slug: express-feelfull-6-phase-wavelength-breakdown
+title: "\"EXPRESS (Feel)\"—Full 6-Phase Wavelength Breakdown"
+content_type: chapter
+release_day: 12
+media: []
+---
+
 ## "EXPRESS (Feel)"—Full 6-Phase Wavelength Breakdown
 
 Now we map the full cycle of Blue's Wavelength. This is the rhythm of emotional expression in relationship—how we rise into connection, peak in attunement, withdraw to discern, sink into conviction or rage, surrender or spiral into misery, and release through catharsis or repress it all. Each phase has its medicine (Rx) and its poison (OD). Learn to recognize both.

--- a/markdown/04-blue/14-practicing-love-off-the-cushion.md
+++ b/markdown/04-blue/14-practicing-love-off-the-cushion.md
@@ -1,3 +1,15 @@
+---
+id: blue-14
+stage: 4
+chapter: 14
+order: 14
+slug: practicing-love-off-the-cushion
+title: "Practicing Love Off the Cushion"
+content_type: chapter
+release_day: 13
+media: []
+---
+
 ## Practicing Love Off the Cushion
 
 Blue is not just a meditation practice. It's a way of being in relationship. And the real test is whether you can carry the principles of Blue—compassion, attunement, vulnerability, integrity—into your daily life.

--- a/markdown/05-orange/01-what-is-orange.md
+++ b/markdown/05-orange/01-what-is-orange.md
@@ -1,3 +1,15 @@
+---
+id: orange-1
+stage: 5
+chapter: 1
+order: 1
+slug: what-is-orange
+title: "What is Orange?"
+content_type: chapter
+release_day: 0
+media: []
+---
+
 ## What is Orange?
 
 Welcome to Orange—the fifth stage of APTITUDE and the beginning of something electric. If the previous stages taught you to ground (Beige), receive (Purple), assert (Red), and attune (Blue), Orange teaches you to *build*. To experiment. To chase curiosity like a hunting dog following a scent through tall grass. To turn problems into projects and projects into mastery.

--- a/markdown/05-orange/02-the-mood-of-orange-understandingintellectual-understanding.md
+++ b/markdown/05-orange/02-the-mood-of-orange-understandingintellectual-understanding.md
@@ -1,3 +1,15 @@
+---
+id: orange-2
+stage: 5
+chapter: 2
+order: 2
+slug: the-mood-of-orange-understandingintellectual-understanding
+title: "The Mood of Orange: Understanding—Intellectual Understanding"
+content_type: chapter
+release_day: 1
+media: []
+---
+
 ## The Mood of Orange: Understanding—Intellectual Understanding
 
 Orange falls within the third category of APTITUDE: **Understanding**. If Yes-And-Ness (Beige and Purple) taught you to trust yourself and Love (Red and Blue) taught you to honor yourself and others, Understanding is where those capacities converge into *competence*. You're learning to make sense of the world—not just emotionally or intuitively, but *systematically*. You're training your mind to become an instrument of clarity.

--- a/markdown/05-orange/03-the-journaling-prompts-of-orange.md
+++ b/markdown/05-orange/03-the-journaling-prompts-of-orange.md
@@ -1,3 +1,15 @@
+---
+id: orange-3
+stage: 5
+chapter: 3
+order: 3
+slug: the-journaling-prompts-of-orange
+title: "The Journaling Prompts of Orange"
+content_type: chapter
+release_day: 2
+media: []
+---
+
 ## The Journaling Prompts of Orange
 
 Orange is the stage of synthesis—of taking the raw materials of your life (curiosities, problems, skills, desires) and alchemizing them into something coherent. The journaling prompts here are designed to help you do exactly that. They're not reflections for the sake of navel-gazing. They're diagnostic tools. Strategic inquiries. Ways of mapping the territory of your own becoming.

--- a/markdown/05-orange/04-the-relationship-to-free-will-at-orange-status-seeker.md
+++ b/markdown/05-orange/04-the-relationship-to-free-will-at-orange-status-seeker.md
@@ -1,3 +1,15 @@
+---
+id: orange-4
+stage: 5
+chapter: 4
+order: 4
+slug: the-relationship-to-free-will-at-orange-status-seeker
+title: "The Relationship to Free Will at Orange: Status Seeker"
+content_type: chapter
+release_day: 3
+media: []
+---
+
 ## The Relationship to Free Will at Orange: Status Seeker
 
 At Orange, the illusion of Free Will gets a serious upgrade—and a serious test.

--- a/markdown/05-orange/05-the-vibe-wavelength-of-orange-collaborate-do.md
+++ b/markdown/05-orange/05-the-vibe-wavelength-of-orange-collaborate-do.md
@@ -1,3 +1,15 @@
+---
+id: orange-5
+stage: 5
+chapter: 5
+order: 5
+slug: the-vibe-wavelength-of-orange-collaborate-do
+title: "The Vibe Wavelength of Orange: Collaborate (Do)"
+content_type: chapter
+release_day: 4
+media: []
+---
+
 ## The Vibe Wavelength of Orange: Collaborate (Do)
 
 Orange introduces a new Mode in the APTITUDE framework: **Collaborate**. Where Inhabit (Beige, Purple) was about building your own foundation and Express (Red, Blue) was about externalizing your selfhood, Collaborate is about *co-creation*. You're no longer working in isolation or simply broadcasting your will. You're entering into dynamic relationship with other agents—people, systems, ideas—and learning to generate something *together* that none of you could create alone.

--- a/markdown/05-orange/06-the-practice-of-orange-wim-hof-method.md
+++ b/markdown/05-orange/06-the-practice-of-orange-wim-hof-method.md
@@ -1,3 +1,15 @@
+---
+id: orange-6
+stage: 5
+chapter: 6
+order: 6
+slug: the-practice-of-orange-wim-hof-method
+title: "The Practice of Orange: Wim Hof Method"
+content_type: chapter
+release_day: 5
+media: []
+---
+
 ## The Practice of Orange: Wim Hof Method
 
 If Purple was 5 minutes and Red was 10, Orange asks for 20. We're scaffolding your capacity for sustained attention, physiological regulation, and energetic resilience. And the practice that does this most powerfully—while also teaching you to collaborate with your own nervous system—is the **Wim Hof Method**.

--- a/markdown/05-orange/07-the-basic-wim-hof-protocol-a-step-by-step-guide.md
+++ b/markdown/05-orange/07-the-basic-wim-hof-protocol-a-step-by-step-guide.md
@@ -1,3 +1,15 @@
+---
+id: orange-7
+stage: 5
+chapter: 7
+order: 7
+slug: the-basic-wim-hof-protocol-a-step-by-step-guide
+title: "The Basic Wim Hof Protocol: A Step-by-Step Guide"
+content_type: chapter
+release_day: 6
+media: []
+---
+
 ## The Basic Wim Hof Protocol: A Step-by-Step Guide
 
 **Total Time: 20 minutes**

--- a/markdown/05-orange/08-step-one-create-your-sacred-laboratory-2-minutes.md
+++ b/markdown/05-orange/08-step-one-create-your-sacred-laboratory-2-minutes.md
@@ -1,3 +1,15 @@
+---
+id: orange-8
+stage: 5
+chapter: 8
+order: 8
+slug: step-one-create-your-sacred-laboratory-2-minutes
+title: "Step One: Create Your Sacred Laboratory (2 minutes)"
+content_type: chapter
+release_day: 7
+media: []
+---
+
 ## Step One: Create Your Sacred Laboratory (2 minutes)
 
 Find a quiet space where you won't be disturbed. This is your laboratory. Your temple. The place where you're going to conduct an experiment on the most fascinating system you'll ever study: yourself.

--- a/markdown/05-orange/09-step-two-the-breathing-rounds-12-15-minutes.md
+++ b/markdown/05-orange/09-step-two-the-breathing-rounds-12-15-minutes.md
@@ -1,3 +1,15 @@
+---
+id: orange-9
+stage: 5
+chapter: 9
+order: 9
+slug: step-two-the-breathing-rounds-12-15-minutes
+title: "Step Two: The Breathing Rounds (12-15 minutes)"
+content_type: chapter
+release_day: 8
+media: []
+---
+
 ## Step Two: The Breathing Rounds (12-15 minutes)
 
 You'll do three full rounds of controlled hyperventilation followed by breath retention. Each round deepens the effect.

--- a/markdown/05-orange/10-step-three-optional-cold-exposure-3-5-minutes.md
+++ b/markdown/05-orange/10-step-three-optional-cold-exposure-3-5-minutes.md
@@ -1,3 +1,15 @@
+---
+id: orange-10
+stage: 5
+chapter: 10
+order: 10
+slug: step-three-optional-cold-exposure-3-5-minutes
+title: "Step Three: Optional Cold Exposure (3-5 minutes)"
+content_type: chapter
+release_day: 9
+media: []
+---
+
 ## Step Three: Optional Cold Exposure (3-5 minutes)
 
 If you have access to a shower, this is where the Wim Hof Method becomes legendary.

--- a/markdown/05-orange/11-the-science-behind-the-method-whats-actually-happening.md
+++ b/markdown/05-orange/11-the-science-behind-the-method-whats-actually-happening.md
@@ -1,3 +1,15 @@
+---
+id: orange-11
+stage: 5
+chapter: 11
+order: 11
+slug: the-science-behind-the-method-whats-actually-happening
+title: "The Science Behind the Method: What's Actually Happening"
+content_type: chapter
+release_day: 10
+media: []
+---
+
 ## The Science Behind the Method: What's Actually Happening
 
 Let's get granular. Because Orange loves to understand *how* things work, not just that they work.

--- a/markdown/05-orange/12-common-experiences-and-how-to-navigate-them.md
+++ b/markdown/05-orange/12-common-experiences-and-how-to-navigate-them.md
@@ -1,3 +1,15 @@
+---
+id: orange-12
+stage: 5
+chapter: 12
+order: 12
+slug: common-experiences-and-how-to-navigate-them
+title: "Common Experiences and How to Navigate Them"
+content_type: chapter
+release_day: 11
+media: []
+---
+
 ## Common Experiences and How to Navigate Them
 
 **Tingling and Cramping**

--- a/markdown/05-orange/13-tracking-your-progress-the-orange-way.md
+++ b/markdown/05-orange/13-tracking-your-progress-the-orange-way.md
@@ -1,3 +1,15 @@
+---
+id: orange-13
+stage: 5
+chapter: 13
+order: 13
+slug: tracking-your-progress-the-orange-way
+title: "Tracking Your Progress: The Orange Way"
+content_type: chapter
+release_day: 12
+media: []
+---
+
 ## Tracking Your Progress: The Orange Way
 
 Because Orange loves data, track your breath retention times. After each round, write down how long you held your breath. Over weeks, you'll see the number climb. This is objective evidence of your nervous system adapting.

--- a/markdown/05-orange/14-alternatives-for-orange-practice.md
+++ b/markdown/05-orange/14-alternatives-for-orange-practice.md
@@ -1,3 +1,15 @@
+---
+id: orange-14
+stage: 5
+chapter: 14
+order: 14
+slug: alternatives-for-orange-practice
+title: "Alternatives for Orange Practice"
+content_type: chapter
+release_day: 13
+media: []
+---
+
 ## Alternatives for Orange Practice
 
 Not everyone can or should do Wim Hof. If you have cardiovascular issues, seizure disorders, or a history of trauma that makes breathwork triggering, listen to your body. APTITUDE is not prescriptive. You're the expert on your own system.

--- a/markdown/05-orange/15-the-default-habit-of-orange-exercise.md
+++ b/markdown/05-orange/15-the-default-habit-of-orange-exercise.md
@@ -1,3 +1,15 @@
+---
+id: orange-15
+stage: 5
+chapter: 15
+order: 15
+slug: the-default-habit-of-orange-exercise
+title: "The Default Habit of Orange: Exercise"
+content_type: chapter
+release_day: 14
+media: []
+---
+
 ## The Default Habit of Orange: Exercise
 
 Every stage has a default habit—the behavior that naturally supports (or undermines) that stage's work. For Orange, it's **Exercise**.

--- a/markdown/05-orange/16-why-exercise-is-non-negotiable-for-understanding.md
+++ b/markdown/05-orange/16-why-exercise-is-non-negotiable-for-understanding.md
@@ -1,3 +1,15 @@
+---
+id: orange-16
+stage: 5
+chapter: 16
+order: 16
+slug: why-exercise-is-non-negotiable-for-understanding
+title: "Why Exercise is Non-Negotiable for Understanding"
+content_type: chapter
+release_day: 15
+media: []
+---
+
 ## Why Exercise is Non-Negotiable for Understanding
 
 Here's what most people miss about exercise: it's not just physical. It's *cognitive*.

--- a/markdown/05-orange/17-how-to-structure-your-exercise-practice.md
+++ b/markdown/05-orange/17-how-to-structure-your-exercise-practice.md
@@ -1,3 +1,15 @@
+---
+id: orange-17
+stage: 5
+chapter: 17
+order: 17
+slug: how-to-structure-your-exercise-practice
+title: "How to Structure Your Exercise Practice"
+content_type: chapter
+release_day: 16
+media: []
+---
+
 ## How to Structure Your Exercise Practice
 
 Orange loves systems, so here's a simple framework.

--- a/markdown/05-orange/18-exercise-as-meditation-the-flow-state.md
+++ b/markdown/05-orange/18-exercise-as-meditation-the-flow-state.md
@@ -1,3 +1,15 @@
+---
+id: orange-18
+stage: 5
+chapter: 18
+order: 18
+slug: exercise-as-meditation-the-flow-state
+title: "Exercise as Meditation: The Flow State"
+content_type: chapter
+release_day: 17
+media: []
+---
+
 ## Exercise as Meditation: The Flow State
 
 When exercise is done right, it becomes a form of moving meditation.

--- a/markdown/05-orange/19-oranges-divine-gender-divine-masculineachievement-and-curios.md
+++ b/markdown/05-orange/19-oranges-divine-gender-divine-masculineachievement-and-curios.md
@@ -1,3 +1,15 @@
+---
+id: orange-19
+stage: 5
+chapter: 19
+order: 19
+slug: oranges-divine-gender-divine-masculineachievement-and-curios
+title: "Orange's Divine Gender: Divine Masculine—Achievement and Curiosity"
+content_type: chapter
+release_day: 18
+media: []
+---
+
 ## Orange's Divine Gender: Divine Masculine—Achievement and Curiosity
 
 Orange swings back to the **Divine Masculine**—the archetypal force of directed action, goal-orientation, and outward expression. Where Purple was receptive (Divine Feminine) and Red was assertive (Divine Masculine) and Blue was devotional (Divine Feminine), Orange is *instrumental*. It's about leveraging your agency to build, test, and achieve.

--- a/markdown/05-orange/20-oranges-gift-the-alchemy-of-problems-and-curiosities.md
+++ b/markdown/05-orange/20-oranges-gift-the-alchemy-of-problems-and-curiosities.md
@@ -1,3 +1,15 @@
+---
+id: orange-20
+stage: 5
+chapter: 20
+order: 20
+slug: oranges-gift-the-alchemy-of-problems-and-curiosities
+title: "Orange's Gift: The Alchemy of Problems and Curiosities"
+content_type: chapter
+release_day: 19
+media: []
+---
+
 ## Orange's Gift: The Alchemy of Problems and Curiosities
 
 The deepest gift of Orange is the realization that *your life's work lives at the intersection of what fascinates you and what breaks your heart*.

--- a/markdown/05-orange/21-three-real-examples-of-curiosity-problem-alchemy.md
+++ b/markdown/05-orange/21-three-real-examples-of-curiosity-problem-alchemy.md
@@ -1,3 +1,15 @@
+---
+id: orange-21
+stage: 5
+chapter: 21
+order: 21
+slug: three-real-examples-of-curiosity-problem-alchemy
+title: "Three Real Examples of Curiosity-Problem Alchemy"
+content_type: chapter
+release_day: 20
+media: []
+---
+
 ## Three Real Examples of Curiosity-Problem Alchemy
 
 Let's get concrete. Here are three examples of how this works in practice.

--- a/markdown/05-orange/22-how-to-find-your-intersection.md
+++ b/markdown/05-orange/22-how-to-find-your-intersection.md
@@ -1,3 +1,15 @@
+---
+id: orange-22
+stage: 5
+chapter: 22
+order: 22
+slug: how-to-find-your-intersection
+title: "How to Find Your Intersection"
+content_type: chapter
+release_day: 21
+media: []
+---
+
 ## How to Find Your Intersection
 
 You don't find it by thinking harder. You find it by *doing the prompts*.

--- a/markdown/05-orange/23-oranges-shadow-when-achievement-becomes-addiction.md
+++ b/markdown/05-orange/23-oranges-shadow-when-achievement-becomes-addiction.md
@@ -1,3 +1,15 @@
+---
+id: orange-23
+stage: 5
+chapter: 23
+order: 23
+slug: oranges-shadow-when-achievement-becomes-addiction
+title: "Orange's Shadow: When Achievement Becomes Addiction"
+content_type: chapter
+release_day: 22
+media: []
+---
+
 ## Orange's Shadow: When Achievement Becomes Addiction
 
 Orange's shadow is seductive. It whispers: *You are what you accomplish*. And if you're not vigilant, you believe it.

--- a/markdown/05-orange/24-collaborate-dofull-6-phase-wavelength-breakdown.md
+++ b/markdown/05-orange/24-collaborate-dofull-6-phase-wavelength-breakdown.md
@@ -1,3 +1,15 @@
+---
+id: orange-24
+stage: 5
+chapter: 24
+order: 24
+slug: collaborate-dofull-6-phase-wavelength-breakdown
+title: "\"COLLABORATE (Do)\"—Full 6-Phase Wavelength Breakdown"
+content_type: chapter
+release_day: 23
+media: []
+---
+
 ## "COLLABORATE (Do)"—Full 6-Phase Wavelength Breakdown
 
 Now we map the full cycle of Orange's Wavelength. This is the rhythm of collaborative experimentation—the scientific method as a lived practice. Each phase has its medicine (Rx) and its poison (OD). Learn to recognize both.

--- a/markdown/05-orange/25-the-prometheus-principle-stealing-fire-from-the-gods.md
+++ b/markdown/05-orange/25-the-prometheus-principle-stealing-fire-from-the-gods.md
@@ -1,3 +1,15 @@
+---
+id: orange-25
+stage: 5
+chapter: 25
+order: 25
+slug: the-prometheus-principle-stealing-fire-from-the-gods
+title: "The Prometheus Principle: Stealing Fire from the Gods"
+content_type: chapter
+release_day: 24
+media: []
+---
+
 ## The Prometheus Principle: Stealing Fire from the Gods
 
 Let me tell you a story. It's old. Greek. And it explains Orange better than any theory.

--- a/markdown/05-orange/26-orange-as-the-theft-of-fire.md
+++ b/markdown/05-orange/26-orange-as-the-theft-of-fire.md
@@ -1,3 +1,15 @@
+---
+id: orange-26
+stage: 5
+chapter: 26
+order: 26
+slug: orange-as-the-theft-of-fire
+title: "Orange as the Theft of Fire"
+content_type: chapter
+release_day: 25
+media: []
+---
+
 ## Orange as the Theft of Fire
 
 Orange is the stage where you steal fire from the gods. Where you stop waiting for salvation, for permission, for the universe to hand you what you need—and you *take* it. Not through domination (that's Red). Through *understanding*.

--- a/markdown/05-orange/27-the-lever-and-the-fulcrum-archimedes-and-the-power-of-unders.md
+++ b/markdown/05-orange/27-the-lever-and-the-fulcrum-archimedes-and-the-power-of-unders.md
@@ -1,3 +1,15 @@
+---
+id: orange-27
+stage: 5
+chapter: 27
+order: 27
+slug: the-lever-and-the-fulcrum-archimedes-and-the-power-of-unders
+title: "The Lever and the Fulcrum: Archimedes and the Power of Understanding"
+content_type: chapter
+release_day: 26
+media: []
+---
+
 ## The Lever and the Fulcrum: Archimedes and the Power of Understanding
 
 "Give me a lever long enough and a fulcrum on which to place it, and I shall move the world."

--- a/markdown/05-orange/28-the-library-of-alexandria-knowledge-as-sacred-responsibility.md
+++ b/markdown/05-orange/28-the-library-of-alexandria-knowledge-as-sacred-responsibility.md
@@ -1,3 +1,15 @@
+---
+id: orange-28
+stage: 5
+chapter: 28
+order: 28
+slug: the-library-of-alexandria-knowledge-as-sacred-responsibility
+title: "The Library of Alexandria: Knowledge as Sacred Responsibility"
+content_type: chapter
+release_day: 27
+media: []
+---
+
 ## The Library of Alexandria: Knowledge as Sacred Responsibility
 
 The Library of Alexandria was one of the great wonders of the ancient world. A repository of scrolls from across the known world—philosophy, science, poetry, medicine, astronomy. Scholars traveled from every corner of the Mediterranean to study there. It was the internet of its time. A hub of intellectual collaboration.

--- a/markdown/05-orange/29-practicing-understanding-off-the-cushion.md
+++ b/markdown/05-orange/29-practicing-understanding-off-the-cushion.md
@@ -1,3 +1,15 @@
+---
+id: orange-29
+stage: 5
+chapter: 29
+order: 29
+slug: practicing-understanding-off-the-cushion
+title: "Practicing Understanding Off the Cushion"
+content_type: chapter
+release_day: 28
+media: []
+---
+
 ## Practicing Understanding Off the Cushion
 
 Orange is not just a meditation practice. It's a way of moving through the world. And the real test is whether you can carry the principles of Orange—curiosity, rigor, collaboration, iteration—into your daily life.

--- a/markdown/06-green/01-what-is-green.md
+++ b/markdown/06-green/01-what-is-green.md
@@ -1,3 +1,15 @@
+---
+id: green-1
+stage: 6
+chapter: 1
+order: 1
+slug: what-is-green
+title: "What is Green?"
+content_type: chapter
+release_day: 0
+media: []
+---
+
 ## What is Green?
 
 If Orange is the building phase—achieving, optimizing, expanding your way toward mastery—Green is the integration phase. The exhale. The moment you stop pushing outward and turn inward to ask: *At what cost?*

--- a/markdown/06-green/02-the-mood-of-green-understandingembodied-understanding.md
+++ b/markdown/06-green/02-the-mood-of-green-understandingembodied-understanding.md
@@ -1,3 +1,15 @@
+---
+id: green-2
+stage: 6
+chapter: 2
+order: 2
+slug: the-mood-of-green-understandingembodied-understanding
+title: "The Mood of Green: Understanding—Embodied Understanding"
+content_type: chapter
+release_day: 1
+media: []
+---
+
 ## The Mood of Green: Understanding—Embodied Understanding
 
 Green is the second expression of **Understanding**, but where Orange approached it intellectually, Green approaches it *somatically*. This is understanding that lives in the gut, in the throat, in the heart. It's the kind of knowing that can't be proven but can't be denied. The kind that makes you say, "I don't have the words for it, but I *feel* it."

--- a/markdown/06-green/03-the-journaling-prompts-of-green.md
+++ b/markdown/06-green/03-the-journaling-prompts-of-green.md
@@ -1,3 +1,15 @@
+---
+id: green-3
+stage: 6
+chapter: 3
+order: 3
+slug: the-journaling-prompts-of-green
+title: "The Journaling Prompts of Green"
+content_type: chapter
+release_day: 2
+media: []
+---
+
 ## The Journaling Prompts of Green
 
 Green's journaling is different. It's not strategic (like Orange) or reflective (like Purple). It's *alchemical*. You're using the page to metabolize what the body can't hold alone. To externalize the shadow so you can see it clearly. To transmute pain into insight.

--- a/markdown/06-green/04-the-relationship-to-free-will-at-green-shadow-glorifier.md
+++ b/markdown/06-green/04-the-relationship-to-free-will-at-green-shadow-glorifier.md
@@ -1,3 +1,15 @@
+---
+id: green-4
+stage: 6
+chapter: 4
+order: 4
+slug: the-relationship-to-free-will-at-green-shadow-glorifier
+title: "The Relationship to Free Will at Green: Shadow Glorifier"
+content_type: chapter
+release_day: 3
+media: []
+---
+
 ## The Relationship to Free Will at Green: Shadow Glorifier
 
 At Green, the relationship to Free Will gets… complicated.

--- a/markdown/06-green/05-the-vibe-wavelength-of-green-collaborate-feel.md
+++ b/markdown/06-green/05-the-vibe-wavelength-of-green-collaborate-feel.md
@@ -1,3 +1,15 @@
+---
+id: green-5
+stage: 6
+chapter: 5
+order: 5
+slug: the-vibe-wavelength-of-green-collaborate-feel
+title: "The Vibe Wavelength of Green: Collaborate (Feel)"
+content_type: chapter
+release_day: 4
+media: []
+---
+
 ## The Vibe Wavelength of Green: Collaborate (Feel)
 
 Green continues the Collaborate Mode, but shifts from **Do** (Orange) to **Feel**. Where Orange collaborated through strategic action, Green collaborates through *emotional attunement*. You're learning to work with others not by dividing tasks, but by sensing the field. By feeling into what's needed. By letting the relational space inform the work.

--- a/markdown/06-green/06-the-practice-of-green-shadow-work-ritual.md
+++ b/markdown/06-green/06-the-practice-of-green-shadow-work-ritual.md
@@ -1,3 +1,15 @@
+---
+id: green-6
+stage: 6
+chapter: 6
+order: 6
+slug: the-practice-of-green-shadow-work-ritual
+title: "The Practice of Green: Shadow Work Ritual"
+content_type: chapter
+release_day: 5
+media: []
+---
+
 ## The Practice of Green: Shadow Work Ritual
 
 We're at 30 minutes now—double Red, triple Purple. You're building the capacity for sustained, focused inner work. And the practice that does this most powerfully at Green is the **Shadow Work Ritual**.

--- a/markdown/06-green/07-what-to-expect-the-first-month-of-shadow-work.md
+++ b/markdown/06-green/07-what-to-expect-the-first-month-of-shadow-work.md
@@ -1,3 +1,15 @@
+---
+id: green-7
+stage: 6
+chapter: 7
+order: 7
+slug: what-to-expect-the-first-month-of-shadow-work
+title: "What to Expect: The First Month of Shadow Work"
+content_type: chapter
+release_day: 6
+media: []
+---
+
 ## What to Expect: The First Month of Shadow Work
 
 Shadow work is not gentle. Especially at first. Here's what might happen:

--- a/markdown/06-green/08-advanced-shadow-work-going-deeper.md
+++ b/markdown/06-green/08-advanced-shadow-work-going-deeper.md
@@ -1,3 +1,15 @@
+---
+id: green-8
+stage: 6
+chapter: 8
+order: 8
+slug: advanced-shadow-work-going-deeper
+title: "Advanced Shadow Work: Going Deeper"
+content_type: chapter
+release_day: 7
+media: []
+---
+
 ## Advanced Shadow Work: Going Deeper
 
 Once you've established the basic practice, you can layer in more sophisticated techniques.

--- a/markdown/06-green/09-alternatives-for-green-practice.md
+++ b/markdown/06-green/09-alternatives-for-green-practice.md
@@ -1,3 +1,15 @@
+---
+id: green-9
+stage: 6
+chapter: 9
+order: 9
+slug: alternatives-for-green-practice
+title: "Alternatives for Green Practice"
+content_type: chapter
+release_day: 8
+media: []
+---
+
 ## Alternatives for Green Practice
 
 Shadow work isn't one-size-fits-all. Some people can't sit in a chair and dialogue with their inner parts—it feels too weird, too dissociative, too triggering. That's okay. Here are other ways to do 30 minutes of embodied integration work.

--- a/markdown/06-green/10-the-default-habit-of-green-active-recovery.md
+++ b/markdown/06-green/10-the-default-habit-of-green-active-recovery.md
@@ -1,3 +1,15 @@
+---
+id: green-10
+stage: 6
+chapter: 10
+order: 10
+slug: the-default-habit-of-green-active-recovery
+title: "The Default Habit of Green: Active Recovery"
+content_type: chapter
+release_day: 9
+media: []
+---
+
 ## The Default Habit of Green: Active Recovery
 
 At Green, the habit shifts from pure *exertion* (Orange's Exercise) to **Active Recovery**. This is the recognition that rest is not passivity—it's a practice. That healing happens in the pauses. That you can't integrate what you haven't given space to metabolize.

--- a/markdown/06-green/11-why-active-recovery-is-essential-for-shadow-work.md
+++ b/markdown/06-green/11-why-active-recovery-is-essential-for-shadow-work.md
@@ -1,3 +1,15 @@
+---
+id: green-11
+stage: 6
+chapter: 11
+order: 11
+slug: why-active-recovery-is-essential-for-shadow-work
+title: "Why Active Recovery is Essential for Shadow Work"
+content_type: chapter
+release_day: 10
+media: []
+---
+
 ## Why Active Recovery is Essential for Shadow Work
 
 Here's what most people don't understand: shadow work is *physiological*, not just psychological. When you meet a disowned part of yourself, your nervous system activates. You're literally processing trauma—and trauma lives in the body.

--- a/markdown/06-green/12-the-rhythm-of-yang-and-yin.md
+++ b/markdown/06-green/12-the-rhythm-of-yang-and-yin.md
@@ -1,3 +1,15 @@
+---
+id: green-12
+stage: 6
+chapter: 12
+order: 12
+slug: the-rhythm-of-yang-and-yin
+title: "The Rhythm of Yang and Yin"
+content_type: chapter
+release_day: 11
+media: []
+---
+
 ## The Rhythm of Yang and Yin
 
 Orange taught you Yang: effort, intensity, building capacity. Green teaches you Yin: softening, receiving, allowing recovery.

--- a/markdown/06-green/13-greens-divine-gender-divine-femininedescent-and-integration.md
+++ b/markdown/06-green/13-greens-divine-gender-divine-femininedescent-and-integration.md
@@ -1,3 +1,15 @@
+---
+id: green-13
+stage: 6
+chapter: 13
+order: 13
+slug: greens-divine-gender-divine-femininedescent-and-integration
+title: "Green's Divine Gender: Divine Feminine—Descent and Integration"
+content_type: chapter
+release_day: 12
+media: []
+---
+
 ## Green's Divine Gender: Divine Feminine—Descent and Integration
 
 Green swings back to the **Divine Feminine**—the archetypal force of receptivity, interiority, and feeling. Where Orange was about *building outward*, Green is about *descending inward*. Where Orange asked "What can I achieve?", Green asks "What have I been avoiding?"

--- a/markdown/06-green/14-greens-gift-the-shadow-as-teacher.md
+++ b/markdown/06-green/14-greens-gift-the-shadow-as-teacher.md
@@ -1,3 +1,15 @@
+---
+id: green-14
+stage: 6
+chapter: 14
+order: 14
+slug: greens-gift-the-shadow-as-teacher
+title: "Green's Gift: The Shadow as Teacher"
+content_type: chapter
+release_day: 13
+media: []
+---
+
 ## Green's Gift: The Shadow as Teacher
 
 The deepest gift of Green is the realization that *your shadow is your greatest teacher*.

--- a/markdown/06-green/15-three-shadow-integration-stories.md
+++ b/markdown/06-green/15-three-shadow-integration-stories.md
@@ -1,3 +1,15 @@
+---
+id: green-15
+stage: 6
+chapter: 15
+order: 15
+slug: three-shadow-integration-stories
+title: "Three Shadow Integration Stories"
+content_type: chapter
+release_day: 14
+media: []
+---
+
 ## Three Shadow Integration Stories
 
 Let's get specific. Here are three real patterns of shadow integration—how the coal becomes gold.

--- a/markdown/06-green/16-the-pattern-from-shadow-to-gift.md
+++ b/markdown/06-green/16-the-pattern-from-shadow-to-gift.md
@@ -1,3 +1,15 @@
+---
+id: green-16
+stage: 6
+chapter: 16
+order: 16
+slug: the-pattern-from-shadow-to-gift
+title: "The Pattern: From Shadow to Gift"
+content_type: chapter
+release_day: 15
+media: []
+---
+
 ## The Pattern: From Shadow to Gift
 
 Notice the structure:

--- a/markdown/06-green/17-greens-shadow-spiritual-bypassing-and-toxic-positivity.md
+++ b/markdown/06-green/17-greens-shadow-spiritual-bypassing-and-toxic-positivity.md
@@ -1,3 +1,15 @@
+---
+id: green-17
+stage: 6
+chapter: 17
+order: 17
+slug: greens-shadow-spiritual-bypassing-and-toxic-positivity
+title: "Green's Shadow: Spiritual Bypassing and Toxic Positivity"
+content_type: chapter
+release_day: 16
+media: []
+---
+
 ## Green's Shadow: Spiritual Bypassing and Toxic Positivity
 
 Green's shadow is subtle. It masquerades as healing. As compassion. As consciousness. But underneath, it's just another form of avoidance.

--- a/markdown/06-green/18-collaborate-feelfull-6-phase-wavelength-breakdown.md
+++ b/markdown/06-green/18-collaborate-feelfull-6-phase-wavelength-breakdown.md
@@ -1,3 +1,15 @@
+---
+id: green-18
+stage: 6
+chapter: 18
+order: 18
+slug: collaborate-feelfull-6-phase-wavelength-breakdown
+title: "\"COLLABORATE (Feel)\"—Full 6-Phase Wavelength Breakdown"
+content_type: chapter
+release_day: 17
+media: []
+---
+
 ## "COLLABORATE (Feel)"—Full 6-Phase Wavelength Breakdown
 
 Now we descend into Green's full Wavelength—the rhythm of deep relational work. This is slower than Orange, softer than Red, more embodied than anything you've encountered so far. Each phase asks you to *feel* your way through, trusting the intelligence of emotion and body.

--- a/markdown/06-green/19-the-descent-of-inanna-the-mythic-template-for-shadow-work.md
+++ b/markdown/06-green/19-the-descent-of-inanna-the-mythic-template-for-shadow-work.md
@@ -1,3 +1,15 @@
+---
+id: green-19
+stage: 6
+chapter: 19
+order: 19
+slug: the-descent-of-inanna-the-mythic-template-for-shadow-work
+title: "The Descent of Inanna: The Mythic Template for Shadow Work"
+content_type: chapter
+release_day: 18
+media: []
+---
+
 ## The Descent of Inanna: The Mythic Template for Shadow Work
 
 Let me tell you the oldest recorded myth about shadow work. It's Sumerian. Four thousand years old. And it maps Green's journey with eerie precision.

--- a/markdown/06-green/20-what-the-myth-teaches-about-green.md
+++ b/markdown/06-green/20-what-the-myth-teaches-about-green.md
@@ -1,3 +1,15 @@
+---
+id: green-20
+stage: 6
+chapter: 20
+order: 20
+slug: what-the-myth-teaches-about-green
+title: "What the Myth Teaches About Green"
+content_type: chapter
+release_day: 19
+media: []
+---
+
 ## What the Myth Teaches About Green
 
 **You Must Descend**

--- a/markdown/06-green/21-ereshkigal-the-sister-in-the-shadow.md
+++ b/markdown/06-green/21-ereshkigal-the-sister-in-the-shadow.md
@@ -1,3 +1,15 @@
+---
+id: green-21
+stage: 6
+chapter: 21
+order: 21
+slug: ereshkigal-the-sister-in-the-shadow
+title: "Ereshkigal: The Sister in the Shadow"
+content_type: chapter
+release_day: 20
+media: []
+---
+
 ## Ereshkigal: The Sister in the Shadow
 
 Here's what most people miss about the myth: Ereshkigal is not evil. She's *grieving*. She's been exiled to the underworld, forgotten by the gods, left to rule over death and decay while her sister gets all the glory.

--- a/markdown/06-green/22-the-katabasis-descent-as-spiritual-practice.md
+++ b/markdown/06-green/22-the-katabasis-descent-as-spiritual-practice.md
@@ -1,3 +1,15 @@
+---
+id: green-22
+stage: 6
+chapter: 22
+order: 22
+slug: the-katabasis-descent-as-spiritual-practice
+title: "The Katabasis: Descent as Spiritual Practice"
+content_type: chapter
+release_day: 21
+media: []
+---
+
 ## The Katabasis: Descent as Spiritual Practice
 
 Inanna's journey is part of a larger mythic pattern called *katabasis*—the descent into the underworld. It shows up everywhere:

--- a/markdown/06-green/23-the-compost-heap-death-as-fertilizer.md
+++ b/markdown/06-green/23-the-compost-heap-death-as-fertilizer.md
@@ -1,3 +1,15 @@
+---
+id: green-23
+stage: 6
+chapter: 23
+order: 23
+slug: the-compost-heap-death-as-fertilizer
+title: "The Compost Heap: Death as Fertilizer"
+content_type: chapter
+release_day: 22
+media: []
+---
+
 ## The Compost Heap: Death as Fertilizer
 
 In permaculture, there's a principle: waste is food. What dies becomes the soil for what grows next. The rotting apple feeds the tree.

--- a/markdown/06-green/24-practicing-embodied-understanding-off-the-cushion.md
+++ b/markdown/06-green/24-practicing-embodied-understanding-off-the-cushion.md
@@ -1,3 +1,15 @@
+---
+id: green-24
+stage: 6
+chapter: 24
+order: 24
+slug: practicing-embodied-understanding-off-the-cushion
+title: "Practicing Embodied Understanding Off the Cushion"
+content_type: chapter
+release_day: 23
+media: []
+---
+
 ## Practicing Embodied Understanding Off the Cushion
 
 Green's practice doesn't end when the timer goes off. The real work is in how you move through your days—how you navigate relationships, how you metabolize emotions, how you honor the body's wisdom in real time.

--- a/markdown/07-yellow/01-what-is-yellow.md
+++ b/markdown/07-yellow/01-what-is-yellow.md
@@ -1,3 +1,15 @@
+---
+id: yellow-1
+stage: 7
+chapter: 1
+order: 1
+slug: what-is-yellow
+title: "What is Yellow?"
+content_type: chapter
+release_day: 0
+media: []
+---
+
 ## What is Yellow?
 
 You've practiced the stages. You've grounded (Beige), received (Purple), asserted (Red), connected (Blue), achieved (Orange), and descended (Green). You've built competence and met your shadow. You've learned to do and to feel, to rise and to fall, to individuate and to belong.

--- a/markdown/07-yellow/02-the-mood-of-yellow-freedomfree-will.md
+++ b/markdown/07-yellow/02-the-mood-of-yellow-freedomfree-will.md
@@ -1,3 +1,15 @@
+---
+id: yellow-2
+stage: 7
+chapter: 2
+order: 2
+slug: the-mood-of-yellow-freedomfree-will
+title: "The Mood of Yellow: Freedom—Free Will"
+content_type: chapter
+release_day: 1
+media: []
+---
+
 ## The Mood of Yellow: Freedom—Free Will
 
 Yellow marks a shift from **Understanding** (Orange and Green) to **Freedom**. And the specific quality of Freedom we're cultivating here is **Free Will**—the capacity to act from choice rather than compulsion.

--- a/markdown/07-yellow/03-the-journaling-prompts-of-yellow.md
+++ b/markdown/07-yellow/03-the-journaling-prompts-of-yellow.md
@@ -1,3 +1,15 @@
+---
+id: yellow-3
+stage: 7
+chapter: 3
+order: 3
+slug: the-journaling-prompts-of-yellow
+title: "The Journaling Prompts of Yellow"
+content_type: chapter
+release_day: 2
+media: []
+---
+
 ## The Journaling Prompts of Yellow
 
 Yellow's journaling is integrative. You're not exploring one dimension (like Orange's problems or Green's shadow). You're weaving *all* the dimensions together. You're looking for the patterns that connect. The threads that run through everything.

--- a/markdown/07-yellow/04-deepening-the-prompts-advanced-journaling-for-yellow.md
+++ b/markdown/07-yellow/04-deepening-the-prompts-advanced-journaling-for-yellow.md
@@ -1,3 +1,15 @@
+---
+id: yellow-4
+stage: 7
+chapter: 4
+order: 4
+slug: deepening-the-prompts-advanced-journaling-for-yellow
+title: "Deepening the Prompts: Advanced Journaling for Yellow"
+content_type: chapter
+release_day: 3
+media: []
+---
+
 ## Deepening the Prompts: Advanced Journaling for Yellow
 
 Once you've established the basic prompts, layer in these more sophisticated practices:

--- a/markdown/07-yellow/05-the-relationship-to-free-will-at-yellow-intentional-actor.md
+++ b/markdown/07-yellow/05-the-relationship-to-free-will-at-yellow-intentional-actor.md
@@ -1,3 +1,15 @@
+---
+id: yellow-5
+stage: 7
+chapter: 5
+order: 5
+slug: the-relationship-to-free-will-at-yellow-intentional-actor
+title: "The Relationship to Free Will at Yellow: Intentional Actor"
+content_type: chapter
+release_day: 4
+media: []
+---
+
 ## The Relationship to Free Will at Yellow: Intentional Actor
 
 For the first time in the spiral, we're not talking about an *illusion* of Free Will. We're talking about the *emergence* of it.

--- a/markdown/07-yellow/06-the-vibe-wavelength-of-yellow-integrate-do.md
+++ b/markdown/07-yellow/06-the-vibe-wavelength-of-yellow-integrate-do.md
@@ -1,3 +1,15 @@
+---
+id: yellow-6
+stage: 7
+chapter: 6
+order: 6
+slug: the-vibe-wavelength-of-yellow-integrate-do
+title: "The Vibe Wavelength of Yellow: Integrate (Do)"
+content_type: chapter
+release_day: 5
+media: []
+---
+
 ## The Vibe Wavelength of Yellow: Integrate (Do)
 
 Yellow introduces the fourth Mode: **Integrate**. Where Inhabit (Beige, Purple) was about internal foundation, Express (Red, Blue) was about externalizing, and Collaborate (Orange, Green) was about co-creation, Integrate is about *synthesis*. You're taking all the parts and weaving them into a coherent whole.

--- a/markdown/07-yellow/07-the-practice-of-yellow-blissy-meditation.md
+++ b/markdown/07-yellow/07-the-practice-of-yellow-blissy-meditation.md
@@ -1,3 +1,15 @@
+---
+id: yellow-7
+stage: 7
+chapter: 7
+order: 7
+slug: the-practice-of-yellow-blissy-meditation
+title: "The Practice of Yellow: Blissy Meditation"
+content_type: chapter
+release_day: 6
+media: []
+---
+
 ## The Practice of Yellow: Blissy Meditation
 
 This is it. The practice we've been building toward since Beige.

--- a/markdown/07-yellow/08-the-neuroscience-of-45-minute-sits.md
+++ b/markdown/07-yellow/08-the-neuroscience-of-45-minute-sits.md
@@ -1,3 +1,15 @@
+---
+id: yellow-8
+stage: 7
+chapter: 8
+order: 8
+slug: the-neuroscience-of-45-minute-sits
+title: "The Neuroscience of 45-Minute Sits"
+content_type: chapter
+release_day: 7
+media: []
+---
+
 ## The Neuroscience of 45-Minute Sits
 
 Let's get specific about what's happening in your brain during this practice.

--- a/markdown/07-yellow/09-what-to-track-building-your-practice-log.md
+++ b/markdown/07-yellow/09-what-to-track-building-your-practice-log.md
@@ -1,3 +1,15 @@
+---
+id: yellow-9
+stage: 7
+chapter: 9
+order: 9
+slug: what-to-track-building-your-practice-log
+title: "What to Track: Building Your Practice Log"
+content_type: chapter
+release_day: 8
+media: []
+---
+
 ## What to Track: Building Your Practice Log
 
 Yellow loves data. So track your sits. After each session, jot down:

--- a/markdown/07-yellow/10-alternatives-for-yellow-practice.md
+++ b/markdown/07-yellow/10-alternatives-for-yellow-practice.md
@@ -1,3 +1,15 @@
+---
+id: yellow-10
+stage: 7
+chapter: 10
+order: 10
+slug: alternatives-for-yellow-practice
+title: "Alternatives for Yellow Practice"
+content_type: chapter
+release_day: 9
+media: []
+---
+
 ## Alternatives for Yellow Practice
 
 If sitting meditation for 45 minutes isn't accessible—due to physical limitations, trauma history, or neurodivergence—there are other ways to cultivate sustained, integrative attention. The key is that whatever practice you choose must be *at least 45 minutes* and must train both concentration and awareness.

--- a/markdown/07-yellow/11-common-meditation-pitfalls-and-how-to-avoid-them.md
+++ b/markdown/07-yellow/11-common-meditation-pitfalls-and-how-to-avoid-them.md
@@ -1,3 +1,15 @@
+---
+id: yellow-11
+stage: 7
+chapter: 11
+order: 11
+slug: common-meditation-pitfalls-and-how-to-avoid-them
+title: "Common Meditation Pitfalls and How to Avoid Them"
+content_type: chapter
+release_day: 10
+media: []
+---
+
 ## Common Meditation Pitfalls and How to Avoid Them
 
 Yellow practitioners are especially susceptible to certain meditation traps. Here's how to navigate them.

--- a/markdown/07-yellow/12-the-default-habit-of-yellow-daily-meditation.md
+++ b/markdown/07-yellow/12-the-default-habit-of-yellow-daily-meditation.md
@@ -1,3 +1,15 @@
+---
+id: yellow-12
+stage: 7
+chapter: 12
+order: 12
+slug: the-default-habit-of-yellow-daily-meditation
+title: "The Default Habit of Yellow: Daily Meditation"
+content_type: chapter
+release_day: 11
+media: []
+---
+
 ## The Default Habit of Yellow: Daily Meditation
 
 At Yellow, the habit *is* the practice. **Daily Meditation**—45 minutes, minimum, every day.

--- a/markdown/07-yellow/13-building-the-daily-meditation-habit-the-first-100-days.md
+++ b/markdown/07-yellow/13-building-the-daily-meditation-habit-the-first-100-days.md
@@ -1,3 +1,15 @@
+---
+id: yellow-13
+stage: 7
+chapter: 13
+order: 13
+slug: building-the-daily-meditation-habit-the-first-100-days
+title: "Building the Daily Meditation Habit: The First 100 Days"
+content_type: chapter
+release_day: 12
+media: []
+---
+
 ## Building the Daily Meditation Habit: The First 100 Days
 
 Here's how to actually make this sustainable.

--- a/markdown/07-yellow/14-troubleshooting-common-obstacles-and-solutions.md
+++ b/markdown/07-yellow/14-troubleshooting-common-obstacles-and-solutions.md
@@ -1,3 +1,15 @@
+---
+id: yellow-14
+stage: 7
+chapter: 14
+order: 14
+slug: troubleshooting-common-obstacles-and-solutions
+title: "Troubleshooting: Common Obstacles and Solutions"
+content_type: chapter
+release_day: 13
+media: []
+---
+
 ## Troubleshooting: Common Obstacles and Solutions
 
 **Obstacle: "I don't have 45 minutes."**

--- a/markdown/07-yellow/15-the-long-game-what-happens-after-a-year.md
+++ b/markdown/07-yellow/15-the-long-game-what-happens-after-a-year.md
@@ -1,3 +1,15 @@
+---
+id: yellow-15
+stage: 7
+chapter: 15
+order: 15
+slug: the-long-game-what-happens-after-a-year
+title: "The Long Game: What Happens After a Year"
+content_type: chapter
+release_day: 14
+media: []
+---
+
 ## The Long Game: What Happens After a Year
 
 After 365 days of 45-minute sits, you'll have logged ~275 hours of meditation. That's not mastery—Culadasa estimates 10,000 hours for full awakening—but it's a foundation.

--- a/markdown/07-yellow/16-yellows-divine-gender-divine-masculinesystems-integration.md
+++ b/markdown/07-yellow/16-yellows-divine-gender-divine-masculinesystems-integration.md
@@ -1,3 +1,15 @@
+---
+id: yellow-16
+stage: 7
+chapter: 16
+order: 16
+slug: yellows-divine-gender-divine-masculinesystems-integration
+title: "Yellow's Divine Gender: Divine Masculine—Systems Integration"
+content_type: chapter
+release_day: 15
+media: []
+---
+
 ## Yellow's Divine Gender: Divine Masculine—Systems Integration
 
 Yellow returns to the **Divine Masculine**—the archetypal force of structure, analysis, and synthesis. But this is not the dominating masculine of Red or the achieving masculine of Orange. This is the *integrative* masculine—the part of consciousness that can hold complexity without collapsing it into simplicity.

--- a/markdown/07-yellow/17-yellows-gift-the-integration-of-all-models.md
+++ b/markdown/07-yellow/17-yellows-gift-the-integration-of-all-models.md
@@ -1,3 +1,15 @@
+---
+id: yellow-17
+stage: 7
+chapter: 17
+order: 17
+slug: yellows-gift-the-integration-of-all-models
+title: "Yellow's Gift: The Integration of All Models"
+content_type: chapter
+release_day: 16
+media: []
+---
+
 ## Yellow's Gift: The Integration of All Models
 
 Yellow's deepest gift is the capacity to hold multiple models without needing them to agree.

--- a/markdown/07-yellow/18-three-examples-of-model-integration-in-action.md
+++ b/markdown/07-yellow/18-three-examples-of-model-integration-in-action.md
@@ -1,3 +1,15 @@
+---
+id: yellow-18
+stage: 7
+chapter: 18
+order: 18
+slug: three-examples-of-model-integration-in-action
+title: "Three Examples of Model Integration in Action"
+content_type: chapter
+release_day: 17
+media: []
+---
+
 ## Three Examples of Model Integration in Action
 
 Let's get concrete. Here's how Yellow actually uses multiple frameworks without getting paralyzed.

--- a/markdown/07-yellow/19-how-to-practice-model-integration.md
+++ b/markdown/07-yellow/19-how-to-practice-model-integration.md
@@ -1,3 +1,15 @@
+---
+id: yellow-19
+stage: 7
+chapter: 19
+order: 19
+slug: how-to-practice-model-integration
+title: "How to Practice Model Integration"
+content_type: chapter
+release_day: 18
+media: []
+---
+
 ## How to Practice Model Integration
 
 Here's the practice:

--- a/markdown/07-yellow/20-yellows-shadow-paralysis-by-analysis.md
+++ b/markdown/07-yellow/20-yellows-shadow-paralysis-by-analysis.md
@@ -1,3 +1,15 @@
+---
+id: yellow-20
+stage: 7
+chapter: 20
+order: 20
+slug: yellows-shadow-paralysis-by-analysis
+title: "Yellow's Shadow: Paralysis by Analysis"
+content_type: chapter
+release_day: 19
+media: []
+---
+
 ## Yellow's Shadow: Paralysis by Analysis
 
 Yellow's shadow is the curse of seeing too much.

--- a/markdown/07-yellow/21-integrate-dofull-6-phase-wavelength-breakdown.md
+++ b/markdown/07-yellow/21-integrate-dofull-6-phase-wavelength-breakdown.md
@@ -1,3 +1,15 @@
+---
+id: yellow-21
+stage: 7
+chapter: 21
+order: 21
+slug: integrate-dofull-6-phase-wavelength-breakdown
+title: "\"INTEGRATE (Do)\"—Full 6-Phase Wavelength Breakdown"
+content_type: chapter
+release_day: 20
+media: []
+---
+
 ## "INTEGRATE (Do)"—Full 6-Phase Wavelength Breakdown
 
 Yellow's Wavelength is the rhythm of focused attention. It's the map of how the mind trains itself—how concentration builds, stabilizes, falters, and renews. Each phase has its medicine and its poison.

--- a/markdown/07-yellow/22-the-odyssey-integration-as-homecoming.md
+++ b/markdown/07-yellow/22-the-odyssey-integration-as-homecoming.md
@@ -1,3 +1,15 @@
+---
+id: yellow-22
+stage: 7
+chapter: 22
+order: 22
+slug: the-odyssey-integration-as-homecoming
+title: "The Odyssey: Integration as Homecoming"
+content_type: chapter
+release_day: 21
+media: []
+---
+
 ## The Odyssey: Integration as Homecoming
 
 Let me tell you about the original story of integration. It's Greek. Three thousand years old. And it maps Yellow's journey with startling precision.

--- a/markdown/07-yellow/23-what-the-odyssey-teaches-about-yellow.md
+++ b/markdown/07-yellow/23-what-the-odyssey-teaches-about-yellow.md
@@ -1,3 +1,15 @@
+---
+id: yellow-23
+stage: 7
+chapter: 23
+order: 23
+slug: what-the-odyssey-teaches-about-yellow
+title: "What the Odyssey Teaches About Yellow"
+content_type: chapter
+release_day: 22
+media: []
+---
+
 ## What the Odyssey Teaches About Yellow
 
 **You Can't Skip the Journey**

--- a/markdown/07-yellow/24-penelopes-test-recognizing-integration.md
+++ b/markdown/07-yellow/24-penelopes-test-recognizing-integration.md
@@ -1,3 +1,15 @@
+---
+id: yellow-24
+stage: 7
+chapter: 24
+order: 24
+slug: penelopes-test-recognizing-integration
+title: "Penelope's Test: Recognizing Integration"
+content_type: chapter
+release_day: 23
+media: []
+---
+
 ## Penelope's Test: Recognizing Integration
 
 But there's one more test. Even after Odysseus reveals himself, Penelope doesn't believe it's him. She tests him with a secret: she tells a servant to move their marriage bed.

--- a/markdown/07-yellow/25-the-spiral-as-odyssey.md
+++ b/markdown/07-yellow/25-the-spiral-as-odyssey.md
@@ -1,3 +1,15 @@
+---
+id: yellow-25
+stage: 7
+chapter: 25
+order: 25
+slug: the-spiral-as-odyssey
+title: "The Spiral as Odyssey"
+content_type: chapter
+release_day: 24
+media: []
+---
+
 ## The Spiral as Odyssey
 
 APTITUDE is your Odyssey. Each stage is an island. Each practice is a test. And Yellow is the return—the integration of everything you've learned on the journey.

--- a/markdown/07-yellow/26-practicing-free-will-off-the-cushion.md
+++ b/markdown/07-yellow/26-practicing-free-will-off-the-cushion.md
@@ -1,3 +1,15 @@
+---
+id: yellow-26
+stage: 7
+chapter: 26
+order: 26
+slug: practicing-free-will-off-the-cushion
+title: "Practicing Free Will Off the Cushion"
+content_type: chapter
+release_day: 25
+media: []
+---
+
 ## Practicing Free Will Off the Cushion
 
 Yellow is where Free Will stops being a concept and becomes a practice. Here's how.

--- a/markdown/08-teal/01-what-is-teal.md
+++ b/markdown/08-teal/01-what-is-teal.md
@@ -1,3 +1,15 @@
+---
+id: teal-1
+stage: 8
+chapter: 1
+order: 1
+slug: what-is-teal
+title: "What is Teal?"
+content_type: chapter
+release_day: 0
+media: []
+---
+
 ## What is Teal?
 
 If Yellow was about integrating *through* the mind—using analysis, systems thinking, and disciplined attention to see all stages as a system—Teal is about integrating *through the soul* by connecting to something beyond the conditioned personality: the **True Self**. This is where the small self meets the **Higher Self**. Where Free Will (Yellow) expands into **True Self Connection** (Teal).

--- a/markdown/08-teal/02-the-mood-of-teal-freedomtrue-self-connection.md
+++ b/markdown/08-teal/02-the-mood-of-teal-freedomtrue-self-connection.md
@@ -1,3 +1,15 @@
+---
+id: teal-2
+stage: 8
+chapter: 2
+order: 2
+slug: the-mood-of-teal-freedomtrue-self-connection
+title: "The Mood of Teal: Freedom—True Self Connection"
+content_type: chapter
+release_day: 1
+media: []
+---
+
 ## The Mood of Teal: Freedom—True Self Connection
 
 Teal continues the category of **Freedom**, but where Yellow cultivated **Free Will**—the capacity to choose consciously—Teal cultivates **True Self Connection**—the capacity to receive guidance from your eternal, transcendent nature.

--- a/markdown/08-teal/03-the-journaling-prompts-of-teal.md
+++ b/markdown/08-teal/03-the-journaling-prompts-of-teal.md
@@ -1,3 +1,15 @@
+---
+id: teal-3
+stage: 8
+chapter: 3
+order: 3
+slug: the-journaling-prompts-of-teal
+title: "The Journaling Prompts of Teal"
+content_type: chapter
+release_day: 2
+media: []
+---
+
 ## The Journaling Prompts of Teal
 
 Teal's journaling is contemplative. You're not strategizing (Orange) or processing shadow (Green) or mapping patterns (Yellow). You're *reflecting*. Letting insights arise from stillness. Trusting the wisdom that emerges when you stop trying to figure everything out.

--- a/markdown/08-teal/04-the-relationship-to-free-will-at-teal-true-self-embodier.md
+++ b/markdown/08-teal/04-the-relationship-to-free-will-at-teal-true-self-embodier.md
@@ -1,3 +1,15 @@
+---
+id: teal-4
+stage: 8
+chapter: 4
+order: 4
+slug: the-relationship-to-free-will-at-teal-true-self-embodier
+title: "The Relationship to Free Will at Teal: True Self Embodier"
+content_type: chapter
+release_day: 3
+media: []
+---
+
 ## The Relationship to Free Will at Teal: True Self Embodier
 
 At Teal, the relationship to Free Will transforms radically.

--- a/markdown/08-teal/05-the-vibe-wavelength-of-teal-integrate-feel.md
+++ b/markdown/08-teal/05-the-vibe-wavelength-of-teal-integrate-feel.md
@@ -1,3 +1,15 @@
+---
+id: teal-5
+stage: 8
+chapter: 5
+order: 5
+slug: the-vibe-wavelength-of-teal-integrate-feel
+title: "The Vibe Wavelength of Teal: Integrate (Feel)"
+content_type: chapter
+release_day: 4
+media: []
+---
+
 ## The Vibe Wavelength of Teal: Integrate (Feel)
 
 Teal continues the **Integrate** Mode but shifts from **Do** (Yellow) to **Feel**. Where Yellow integrated through analysis and discipline, Teal integrates through *receptivity*. You're not building synthesis—you're *allowing* it to emerge.

--- a/markdown/08-teal/06-the-practice-of-teal-dog-walkin-shamanism.md
+++ b/markdown/08-teal/06-the-practice-of-teal-dog-walkin-shamanism.md
@@ -1,3 +1,15 @@
+---
+id: teal-6
+stage: 8
+chapter: 6
+order: 6
+slug: the-practice-of-teal-dog-walkin-shamanism
+title: "The Practice of Teal: Dog Walkin' Shamanism"
+content_type: chapter
+release_day: 5
+media: []
+---
+
 ## The Practice of Teal: Dog Walkin' Shamanism
 
 Teal's practice is radically different from every stage that came before. You're not sitting on a cushion in a quiet room, grinding through 45 minutes of focused attention. You're *walking*. Preferably in nature. Preferably with a dog (if you have one) or alone if you don't.

--- a/markdown/08-teal/07-alternatives-for-teal-practice.md
+++ b/markdown/08-teal/07-alternatives-for-teal-practice.md
@@ -1,1 +1,13 @@
+---
+id: teal-7
+stage: 8
+chapter: 7
+order: 7
+slug: alternatives-for-teal-practice
+title: "Alternatives for Teal Practice"
+content_type: chapter
+release_day: 6
+media: []
+---
+
 ## Alternatives for Teal Practice

--- a/markdown/08-teal/08-the-practice-decoded-what-dog-walkin-shamanism-actually-is.md
+++ b/markdown/08-teal/08-the-practice-decoded-what-dog-walkin-shamanism-actually-is.md
@@ -1,3 +1,15 @@
+---
+id: teal-8
+stage: 8
+chapter: 8
+order: 8
+slug: the-practice-decoded-what-dog-walkin-shamanism-actually-is
+title: "The Practice Decoded: What Dog Walkin' Shamanism Actually Is"
+content_type: chapter
+release_day: 7
+media: []
+---
+
 ## The Practice Decoded: What Dog Walkin' Shamanism Actually Is
 
 This practice has an unusual name for a reason. It's not "walking meditation" or "nature contemplation." It's **Dog Walkin' Shamanism**—and that matters.

--- a/markdown/08-teal/09-the-neuropsychology-of-extended-walking.md
+++ b/markdown/08-teal/09-the-neuropsychology-of-extended-walking.md
@@ -1,3 +1,15 @@
+---
+id: teal-9
+stage: 8
+chapter: 9
+order: 9
+slug: the-neuropsychology-of-extended-walking
+title: "The Neuropsychology of Extended Walking"
+content_type: chapter
+release_day: 8
+media: []
+---
+
 ## The Neuropsychology of Extended Walking
 
 Why does walking for an hour produce different effects than sitting meditation?

--- a/markdown/08-teal/10-advanced-dog-walkin-sensory-gating-practice.md
+++ b/markdown/08-teal/10-advanced-dog-walkin-sensory-gating-practice.md
@@ -1,3 +1,15 @@
+---
+id: teal-10
+stage: 8
+chapter: 10
+order: 10
+slug: advanced-dog-walkin-sensory-gating-practice
+title: "Advanced Dog Walkin': Sensory Gating Practice"
+content_type: chapter
+release_day: 9
+media: []
+---
+
 ## Advanced Dog Walkin': Sensory Gating Practice
 
 Once you've established the basic 60-minute walk, you can deepen it with **sensory gating**—the practice of sequentially opening and closing each sense.

--- a/markdown/08-teal/11-the-moon-lodge-teals-mythology.md
+++ b/markdown/08-teal/11-the-moon-lodge-teals-mythology.md
@@ -1,3 +1,15 @@
+---
+id: teal-11
+stage: 8
+chapter: 11
+order: 11
+slug: the-moon-lodge-teals-mythology
+title: "The Moon Lodge: Teal's Mythology"
+content_type: chapter
+release_day: 10
+media: []
+---
+
 ## The Moon Lodge: Teal's Mythology
 
 In many indigenous traditions, there's a practice called the Moon Lodge—a space where people (especially women during menstruation) go to be alone, to rest, to listen to the deeper rhythms.

--- a/markdown/08-teal/12-beginners-mind-the-koan-of-not-knowing.md
+++ b/markdown/08-teal/12-beginners-mind-the-koan-of-not-knowing.md
@@ -1,3 +1,15 @@
+---
+id: teal-12
+stage: 8
+chapter: 12
+order: 12
+slug: beginners-mind-the-koan-of-not-knowing
+title: "Beginner's Mind: The Koan of Not-Knowing"
+content_type: chapter
+release_day: 11
+media: []
+---
+
 ## Beginner's Mind: The Koan of Not-Knowing
 
 Shunryu Suzuki's teaching is central to Teal: "In the beginner's mind there are many possibilities. In the expert's mind there are few."

--- a/markdown/08-teal/13-the-default-habit-of-teal-baby-waterfall-conventions.md
+++ b/markdown/08-teal/13-the-default-habit-of-teal-baby-waterfall-conventions.md
@@ -1,3 +1,15 @@
+---
+id: teal-13
+stage: 8
+chapter: 13
+order: 13
+slug: the-default-habit-of-teal-baby-waterfall-conventions
+title: "The Default Habit of Teal: Baby Waterfall Conventions"
+content_type: chapter
+release_day: 12
+media: []
+---
+
 ## The Default Habit of Teal: Baby Waterfall Conventions
 
 Teal's habit is subtle but profound: **Baby Waterfall Conventions**.

--- a/markdown/08-teal/14-teals-divine-gender-divine-femininereceptive-integration.md
+++ b/markdown/08-teal/14-teals-divine-gender-divine-femininereceptive-integration.md
@@ -1,3 +1,15 @@
+---
+id: teal-14
+stage: 8
+chapter: 14
+order: 14
+slug: teals-divine-gender-divine-femininereceptive-integration
+title: "Teal's Divine Gender: Divine Feminine—Receptive Integration"
+content_type: chapter
+release_day: 13
+media: []
+---
+
 ## Teal's Divine Gender: Divine Feminine—Receptive Integration
 
 Teal swings back to the **Divine Feminine**—the archetypal force of receptivity, allowing, and surrender. Where Yellow was active integration (building systems, disciplining attention), Teal is *passive* integration (allowing coherence to emerge on its own).

--- a/markdown/08-teal/15-teals-gift-beginners-mind.md
+++ b/markdown/08-teal/15-teals-gift-beginners-mind.md
@@ -1,3 +1,15 @@
+---
+id: teal-15
+stage: 8
+chapter: 15
+order: 15
+slug: teals-gift-beginners-mind
+title: "Teal's Gift: Beginner's Mind"
+content_type: chapter
+release_day: 14
+media: []
+---
+
 ## Teal's Gift: Beginner's Mind
 
 The deepest gift of Teal is what Suzuki calls **Beginner's Mind**—the capacity to see reality fresh, unfiltered by concepts, judgments, or expectations.

--- a/markdown/08-teal/16-teals-shadow-spiritual-dissociation.md
+++ b/markdown/08-teal/16-teals-shadow-spiritual-dissociation.md
@@ -1,3 +1,15 @@
+---
+id: teal-16
+stage: 8
+chapter: 16
+order: 16
+slug: teals-shadow-spiritual-dissociation
+title: "Teal's Shadow: Spiritual Dissociation"
+content_type: chapter
+release_day: 15
+media: []
+---
+
 ## Teal's Shadow: Spiritual Dissociation
 
 Teal's shadow is the danger of confusing *witnessing* with *dissociating*.

--- a/markdown/08-teal/17-integrate-feelfull-6-phase-wavelength-breakdown.md
+++ b/markdown/08-teal/17-integrate-feelfull-6-phase-wavelength-breakdown.md
@@ -1,3 +1,15 @@
+---
+id: teal-17
+stage: 8
+chapter: 17
+order: 17
+slug: integrate-feelfull-6-phase-wavelength-breakdown
+title: "\"INTEGRATE (Feel)\"—Full 6-Phase Wavelength Breakdown"
+content_type: chapter
+release_day: 16
+media: []
+---
+
 ## "INTEGRATE (Feel)"—Full 6-Phase Wavelength Breakdown
 
 Teal's Wavelength is the same structure as Yellow's, but the *quality* is different. Where Yellow was effortful, Teal is effortless. Where Yellow was directed, Teal is receptive. Let's walk through how each phase *feels* at Teal.

--- a/markdown/08-teal/18-practicing-equanimity-off-the-cushion.md
+++ b/markdown/08-teal/18-practicing-equanimity-off-the-cushion.md
@@ -1,3 +1,15 @@
+---
+id: teal-18
+stage: 8
+chapter: 18
+order: 18
+slug: practicing-equanimity-off-the-cushion
+title: "Practicing Equanimity Off the Cushion"
+content_type: chapter
+release_day: 17
+media: []
+---
+
 ## Practicing Equanimity Off the Cushion
 
 Teal is not about having profound experiences in meditation. It's about bringing the Witness into every moment of your life. Here's how.

--- a/markdown/08-teal/19-baby-waterfall-conventions-the-architecture-of-micro-practic.md
+++ b/markdown/08-teal/19-baby-waterfall-conventions-the-architecture-of-micro-practic.md
@@ -1,3 +1,15 @@
+---
+id: teal-19
+stage: 8
+chapter: 19
+order: 19
+slug: baby-waterfall-conventions-the-architecture-of-micro-practic
+title: "Baby Waterfall Conventions: The Architecture of Micro-Practice"
+content_type: chapter
+release_day: 18
+media: []
+---
+
 ## Baby Waterfall Conventions: The Architecture of Micro-Practice
 
 The Baby Waterfall Convention is Teal's signature contribution to habit design. It's deceptively simple: create tiny rituals throughout your day that serve as "reset points"—moments where you drop back into presence.

--- a/markdown/08-teal/20-the-witness-and-the-participator-teals-paradox.md
+++ b/markdown/08-teal/20-the-witness-and-the-participator-teals-paradox.md
@@ -1,3 +1,15 @@
+---
+id: teal-20
+stage: 8
+chapter: 20
+order: 20
+slug: the-witness-and-the-participator-teals-paradox
+title: "The Witness and the Participator: Teal's Paradox"
+content_type: chapter
+release_day: 19
+media: []
+---
+
 ## The Witness and the Participator: Teal's Paradox
 
 Here's the paradox Teal must hold: you're cultivating the Witness (the part that observes without being moved) *and* you're fully participating in life (engaging, feeling, acting).

--- a/markdown/08-teal/21-three-stories-of-equanimity-in-action.md
+++ b/markdown/08-teal/21-three-stories-of-equanimity-in-action.md
@@ -1,3 +1,15 @@
+---
+id: teal-21
+stage: 8
+chapter: 21
+order: 21
+slug: three-stories-of-equanimity-in-action
+title: "Three Stories of Equanimity in Action"
+content_type: chapter
+release_day: 20
+media: []
+---
+
 ## Three Stories of Equanimity in Action
 
 Let me show you what this looks like in real life.

--- a/markdown/08-teal/22-the-long-game-what-happens-after-a-year-at-teal.md
+++ b/markdown/08-teal/22-the-long-game-what-happens-after-a-year-at-teal.md
@@ -1,3 +1,15 @@
+---
+id: teal-22
+stage: 8
+chapter: 22
+order: 22
+slug: the-long-game-what-happens-after-a-year-at-teal
+title: "The Long Game: What Happens After a Year at Teal"
+content_type: chapter
+release_day: 21
+media: []
+---
+
 ## The Long Game: What Happens After a Year at Teal
 
 After 365 days of Dog Walkin' Shamanism (60 min, 4x/week) and Baby Waterfall Conventions (daily), here's what typically shifts:

--- a/markdown/08-teal/23-journaling-prompt-expansion-deepening-your-reflections.md
+++ b/markdown/08-teal/23-journaling-prompt-expansion-deepening-your-reflections.md
@@ -1,3 +1,15 @@
+---
+id: teal-23
+stage: 8
+chapter: 23
+order: 23
+slug: journaling-prompt-expansion-deepening-your-reflections
+title: "Journaling Prompt Expansion: Deepening Your Reflections"
+content_type: chapter
+release_day: 22
+media: []
+---
+
 ## Journaling Prompt Expansion: Deepening Your Reflections
 
 Let's expand on those journaling prompts with concrete guidance and examples.

--- a/markdown/08-teal/24-the-default-habit-deepened-baby-waterfall-conventions-as-lif.md
+++ b/markdown/08-teal/24-the-default-habit-deepened-baby-waterfall-conventions-as-lif.md
@@ -1,3 +1,15 @@
+---
+id: teal-24
+stage: 8
+chapter: 24
+order: 24
+slug: the-default-habit-deepened-baby-waterfall-conventions-as-lif
+title: "The Default Habit Deepened: Baby Waterfall Conventions as Life Design"
+content_type: chapter
+release_day: 23
+media: []
+---
+
 ## The Default Habit Deepened: Baby Waterfall Conventions as Life Design
 
 Let's go deeper into why Baby Waterfall Conventions are revolutionary.

--- a/markdown/09-ultraviolet/01-what-is-ultraviolet.md
+++ b/markdown/09-ultraviolet/01-what-is-ultraviolet.md
@@ -1,3 +1,15 @@
+---
+id: ultraviolet-1
+stage: 9
+chapter: 1
+order: 1
+slug: what-is-ultraviolet
+title: "What is Ultraviolet?"
+content_type: chapter
+release_day: 0
+media: []
+---
+
 ## What is Ultraviolet?
 
 If the journey so far has been about *becoming* whole—building the foundation, integrating the shadow, training attention, resting in awareness—Ultraviolet is where you stop becoming and start *recognizing*.

--- a/markdown/09-ultraviolet/02-the-mood-of-ultraviolet-wholenesshierarchy.md
+++ b/markdown/09-ultraviolet/02-the-mood-of-ultraviolet-wholenesshierarchy.md
@@ -1,3 +1,15 @@
+---
+id: ultraviolet-2
+stage: 9
+chapter: 2
+order: 2
+slug: the-mood-of-ultraviolet-wholenesshierarchy
+title: "The Mood of Ultraviolet: Wholeness—Developmental Complexity"
+content_type: chapter
+release_day: 1
+media: []
+---
+
 ## The Mood of Ultraviolet: Wholeness—Developmental Complexity
 
 Ultraviolet introduces the final category of APTITUDE: **Wholeness**. You've moved through Yes-And-Ness (Beige, Purple), Love (Red, Blue), Understanding (Orange, Green), and Freedom (Yellow, Teal). Now you arrive at Wholeness—the recognition that all of it was always one thing.

--- a/markdown/09-ultraviolet/03-the-journaling-prompts-of-ultraviolet.md
+++ b/markdown/09-ultraviolet/03-the-journaling-prompts-of-ultraviolet.md
@@ -1,3 +1,15 @@
+---
+id: ultraviolet-3
+stage: 9
+chapter: 3
+order: 3
+slug: the-journaling-prompts-of-ultraviolet
+title: "The Journaling Prompts of Ultraviolet"
+content_type: chapter
+release_day: 2
+media: []
+---
+
 ## The Journaling Prompts of Ultraviolet
 
 Ultraviolet's journaling is contemplative, precise, and devoted. You're not exploring (Orange), processing (Green), or mapping (Yellow) anymore. You're *deepening*. You're returning to the same questions again and again, not because you haven't answered them, but because each time you ask, you see more.

--- a/markdown/09-ultraviolet/04-the-relationship-to-free-will-at-ultraviolet-hierarchical-or.md
+++ b/markdown/09-ultraviolet/04-the-relationship-to-free-will-at-ultraviolet-hierarchical-or.md
@@ -1,3 +1,15 @@
+---
+id: ultraviolet-4
+stage: 9
+chapter: 4
+order: 4
+slug: the-relationship-to-free-will-at-ultraviolet-hierarchical-or
+title: "The Relationship to Free Will at Ultraviolet: Hierarchical Organizer"
+content_type: chapter
+release_day: 3
+media: []
+---
+
 ## The Relationship to Free Will at Ultraviolet: Hierarchical Organizer
 
 At Ultraviolet, the relationship to Free Will becomes *functional*.

--- a/markdown/09-ultraviolet/05-the-vibe-wavelength-of-ultraviolet-absorb-do.md
+++ b/markdown/09-ultraviolet/05-the-vibe-wavelength-of-ultraviolet-absorb-do.md
@@ -1,3 +1,15 @@
+---
+id: ultraviolet-5
+stage: 9
+chapter: 5
+order: 5
+slug: the-vibe-wavelength-of-ultraviolet-absorb-do
+title: "The Vibe Wavelength of Ultraviolet: Absorb (Do)"
+content_type: chapter
+release_day: 4
+media: []
+---
+
 ## The Vibe Wavelength of Ultraviolet: Absorb (Do)
 
 Ultraviolet introduces the fifth Mode: **Absorb**. Where Inhabit was about building yourself, Express was about externalizing, Collaborate was about co-creating, and Integrate was about synthesizing, Absorb is about *taking in the whole*.

--- a/markdown/09-ultraviolet/06-the-practice-of-ultraviolet-cultivating-samatha-jhanas.md
+++ b/markdown/09-ultraviolet/06-the-practice-of-ultraviolet-cultivating-samatha-jhanas.md
@@ -1,3 +1,15 @@
+---
+id: ultraviolet-6
+stage: 9
+chapter: 6
+order: 6
+slug: the-practice-of-ultraviolet-cultivating-samatha-jhanas
+title: "The Practice of Ultraviolet: Cultivating Samatha Jhanas"
+content_type: chapter
+release_day: 5
+media: []
+---
+
 ## The Practice of Ultraviolet: Cultivating Samatha Jhanas
 
 Ultraviolet's practice is the most advanced formal meditation in the APTITUDE sequence: **Cultivating the Samatha Jhanas**.

--- a/markdown/09-ultraviolet/07-alternatives-for-ultraviolet-practice.md
+++ b/markdown/09-ultraviolet/07-alternatives-for-ultraviolet-practice.md
@@ -1,3 +1,15 @@
+---
+id: ultraviolet-7
+stage: 9
+chapter: 7
+order: 7
+slug: alternatives-for-ultraviolet-practice
+title: "Alternatives for Ultraviolet Practice"
+content_type: chapter
+release_day: 6
+media: []
+---
+
 ## Alternatives for Ultraviolet Practice
 
 If jhana practice isn't accessible or resonant for you, here are other advanced practices that cultivate the same depth of absorption:

--- a/markdown/09-ultraviolet/08-the-default-habit-of-ultraviolet-meditation-retreats.md
+++ b/markdown/09-ultraviolet/08-the-default-habit-of-ultraviolet-meditation-retreats.md
@@ -1,3 +1,15 @@
+---
+id: ultraviolet-8
+stage: 9
+chapter: 8
+order: 8
+slug: the-default-habit-of-ultraviolet-meditation-retreats
+title: "The Default Habit of Ultraviolet: Meditation Retreats"
+content_type: chapter
+release_day: 7
+media: []
+---
+
 ## The Default Habit of Ultraviolet: Meditation Retreats
 
 At Ultraviolet, daily practice is no longer enough. You need *retreat*.

--- a/markdown/09-ultraviolet/09-ultraviolets-divine-gender-divine-masculineprecision-and-hie.md
+++ b/markdown/09-ultraviolet/09-ultraviolets-divine-gender-divine-masculineprecision-and-hie.md
@@ -1,3 +1,15 @@
+---
+id: ultraviolet-9
+stage: 9
+chapter: 9
+order: 9
+slug: ultraviolets-divine-gender-divine-masculineprecision-and-hie
+title: "Ultraviolet's Divine Gender: Divine Masculine—Precision and Hierarchy"
+content_type: chapter
+release_day: 8
+media: []
+---
+
 ## Ultraviolet's Divine Gender: Divine Masculine—Precision and Hierarchy
 
 Ultraviolet returns to the **Divine Masculine**—but this is the Masculine at its most refined. This is not the dominating force of Red or the achieving drive of Orange or the analytical mind of Yellow. This is the Masculine as *precision*. As discernment. As the capacity to see clearly and organize complexity into coherence.

--- a/markdown/09-ultraviolet/10-ultraviolets-gift-the-recognition-of-natural-hierarchy.md
+++ b/markdown/09-ultraviolet/10-ultraviolets-gift-the-recognition-of-natural-hierarchy.md
@@ -1,3 +1,15 @@
+---
+id: ultraviolet-10
+stage: 9
+chapter: 10
+order: 10
+slug: ultraviolets-gift-the-recognition-of-natural-hierarchy
+title: "Ultraviolet's Gift: The Recognition of Developmental Complexity"
+content_type: chapter
+release_day: 9
+media: []
+---
+
 ## Ultraviolet's Gift: The Recognition of Developmental Complexity
 
 The deepest gift of Ultraviolet is the recognition that *complexity is not superiority—it's scaffolding*.

--- a/markdown/09-ultraviolet/11-ultraviolets-shadow-spiritual-superiority.md
+++ b/markdown/09-ultraviolet/11-ultraviolets-shadow-spiritual-superiority.md
@@ -1,3 +1,15 @@
+---
+id: ultraviolet-11
+stage: 9
+chapter: 11
+order: 11
+slug: ultraviolets-shadow-spiritual-superiority
+title: "Ultraviolet's Shadow: Spiritual Superiority"
+content_type: chapter
+release_day: 10
+media: []
+---
+
 ## Ultraviolet's Shadow: Spiritual Superiority
 
 Ultraviolet's shadow is the most seductive of all: **spiritual superiority**.

--- a/markdown/09-ultraviolet/12-absorb-dofull-6-phase-wavelength-breakdown.md
+++ b/markdown/09-ultraviolet/12-absorb-dofull-6-phase-wavelength-breakdown.md
@@ -1,3 +1,15 @@
+---
+id: ultraviolet-12
+stage: 9
+chapter: 12
+order: 12
+slug: absorb-dofull-6-phase-wavelength-breakdown
+title: "\"ABSORB (Do)\"—Full 6-Phase Wavelength Breakdown"
+content_type: chapter
+release_day: 11
+media: []
+---
+
 ## "ABSORB (Do)"—Full 6-Phase Wavelength Breakdown
 
 Ultraviolet's Wavelength is the rhythm of deepening realization. Each phase is a movement in the dance of awakening—and each has its medicine and poison.

--- a/markdown/09-ultraviolet/13-practicing-hierarchy-off-the-cushion.md
+++ b/markdown/09-ultraviolet/13-practicing-hierarchy-off-the-cushion.md
@@ -1,3 +1,15 @@
+---
+id: ultraviolet-13
+stage: 9
+chapter: 13
+order: 13
+slug: practicing-hierarchy-off-the-cushion
+title: "Practicing Hierarchy Off the Cushion"
+content_type: chapter
+release_day: 12
+media: []
+---
+
 ## Practicing Hierarchy Off the Cushion
 
 Ultraviolet is not just about retreat. It's about bringing the recognition of hierarchy into your daily life. Here's how.

--- a/markdown/09-ultraviolet/14-the-75-minute-threshold-why-this-is-the-gateway-practice.md
+++ b/markdown/09-ultraviolet/14-the-75-minute-threshold-why-this-is-the-gateway-practice.md
@@ -1,3 +1,15 @@
+---
+id: ultraviolet-14
+stage: 9
+chapter: 14
+order: 14
+slug: the-75-minute-threshold-why-this-is-the-gateway-practice
+title: "The 75-Minute Threshold: Why This Is the Gateway Practice"
+content_type: chapter
+release_day: 13
+media: []
+---
+
 ## The 75-Minute Threshold: Why This Is the Gateway Practice
 
 You've been building toward this since Beige. 5 minutes became 10. 10 became 15. Then 20, 30, 45, 60. And now: 75.

--- a/markdown/09-ultraviolet/15-becoming-nobody-the-dissolution-of-spiritual-identity.md
+++ b/markdown/09-ultraviolet/15-becoming-nobody-the-dissolution-of-spiritual-identity.md
@@ -1,3 +1,15 @@
+---
+id: ultraviolet-15
+stage: 9
+chapter: 15
+order: 15
+slug: becoming-nobody-the-dissolution-of-spiritual-identity
+title: "Becoming Nobody: The Dissolution of Spiritual Identity"
+content_type: chapter
+release_day: 14
+media: []
+---
+
 ## Becoming Nobody: The Dissolution of Spiritual Identity
 
 Here's Ultraviolet's greatest test: Can you let go of being "spiritual"?

--- a/markdown/09-ultraviolet/16-the-ultraviolet-shadow-when-emptiness-becomes-nihilism.md
+++ b/markdown/09-ultraviolet/16-the-ultraviolet-shadow-when-emptiness-becomes-nihilism.md
@@ -1,3 +1,15 @@
+---
+id: ultraviolet-16
+stage: 9
+chapter: 16
+order: 16
+slug: the-ultraviolet-shadow-when-emptiness-becomes-nihilism
+title: "The Ultraviolet Shadow: When Emptiness Becomes Nihilism"
+content_type: chapter
+release_day: 15
+media: []
+---
+
 ## The Ultraviolet Shadow: When Emptiness Becomes Nihilism
 
 Ultraviolet's shadow is subtle and dangerous: mistaking emptiness for meaninglessness.

--- a/markdown/09-ultraviolet/17-the-practice-as-prayer-what-happens-at-75-minutes.md
+++ b/markdown/09-ultraviolet/17-the-practice-as-prayer-what-happens-at-75-minutes.md
@@ -1,3 +1,15 @@
+---
+id: ultraviolet-17
+stage: 9
+chapter: 17
+order: 17
+slug: the-practice-as-prayer-what-happens-at-75-minutes
+title: "The Practice as Prayer: What Happens at 75 Minutes"
+content_type: chapter
+release_day: 16
+media: []
+---
+
 ## The Practice as Prayer: What Happens at 75 Minutes
 
 Let me walk you through what actually happens in a 75-minute sit. Because this is different from anything you've done before.

--- a/markdown/09-ultraviolet/18-the-hierarchy-that-serves-skillful-use-of-developmental-mode.md
+++ b/markdown/09-ultraviolet/18-the-hierarchy-that-serves-skillful-use-of-developmental-mode.md
@@ -1,3 +1,15 @@
+---
+id: ultraviolet-18
+stage: 9
+chapter: 18
+order: 18
+slug: the-hierarchy-that-serves-skillful-use-of-developmental-mode
+title: "The Hierarchy That Serves: Skillful Use of Developmental Models"
+content_type: chapter
+release_day: 17
+media: []
+---
+
 ## The Hierarchy That Serves: Skillful Use of Developmental Models
 
 Ultraviolet is where you've integrated Spiral Dynamics so fully that you can use it without being imprisoned by it.

--- a/markdown/09-ultraviolet/19-the-dark-night-ultraviolets-inevitable-passage.md
+++ b/markdown/09-ultraviolet/19-the-dark-night-ultraviolets-inevitable-passage.md
@@ -1,3 +1,15 @@
+---
+id: ultraviolet-19
+stage: 9
+chapter: 19
+order: 19
+slug: the-dark-night-ultraviolets-inevitable-passage
+title: "The Dark Night: Ultraviolet's Inevitable Passage"
+content_type: chapter
+release_day: 18
+media: []
+---
+
 ## The Dark Night: Ultraviolet's Inevitable Passage
 
 At some point in Ultraviolet, you will hit what St. John of the Cross called "the dark night of the soul." This is not metaphor. This is a predictable stage of advanced practice.

--- a/markdown/09-ultraviolet/20-what-450-hours-of-meditation-produces-a-developmental-milest.md
+++ b/markdown/09-ultraviolet/20-what-450-hours-of-meditation-produces-a-developmental-milest.md
@@ -1,3 +1,15 @@
+---
+id: ultraviolet-20
+stage: 9
+chapter: 20
+order: 20
+slug: what-450-hours-of-meditation-produces-a-developmental-milest
+title: "What 450 Hours of Meditation Produces: A Developmental Milestone"
+content_type: chapter
+release_day: 19
+media: []
+---
+
 ## What 450 Hours of Meditation Produces: A Developmental Milestone
 
 By the end of Ultraviolet, if you've done 75 minutes 4x/week for a year, you'll have logged ~450 hours of formal practice.

--- a/markdown/09-ultraviolet/21-the-void-practice-advanced-meditation-techniques-for-ultravi.md
+++ b/markdown/09-ultraviolet/21-the-void-practice-advanced-meditation-techniques-for-ultravi.md
@@ -1,3 +1,15 @@
+---
+id: ultraviolet-21
+stage: 9
+chapter: 21
+order: 21
+slug: the-void-practice-advanced-meditation-techniques-for-ultravi
+title: "The Void Practice: Advanced Meditation Techniques for Ultraviolet"
+content_type: chapter
+release_day: 20
+media: []
+---
+
 ## The Void Practice: Advanced Meditation Techniques for Ultraviolet
 
 At 75 minutes, you're ready for more advanced methods. Here's one that's particularly suited to Ultraviolet: **Void Practice**.

--- a/markdown/10-clearlight/01-what-is-clear-light.md
+++ b/markdown/10-clearlight/01-what-is-clear-light.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-1
+stage: 10
+chapter: 1
+order: 1
+slug: what-is-clear-light
+title: "What is Clear Light?"
+content_type: chapter
+release_day: 0
+media: []
+---
+
 ## What is Clear Light?
 
 You've arrived. And paradoxically, you've discovered there was never anything to arrive to. Because there was never anyone arriving.

--- a/markdown/10-clearlight/02-the-mood-of-clear-light-wholenessemptiness.md
+++ b/markdown/10-clearlight/02-the-mood-of-clear-light-wholenessemptiness.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-2
+stage: 10
+chapter: 2
+order: 2
+slug: the-mood-of-clear-light-wholenessemptiness
+title: "The Mood of Clear Light: Wholeness—Emptiness"
+content_type: chapter
+release_day: 1
+media: []
+---
+
 ## The Mood of Clear Light: Wholeness—Emptiness
 
 Clear Light completes the category of **Wholeness**, and it does so through the recognition of **Emptiness** (śūnyatā)—the direct experiential knowing that all phenomena are empty of inherent, independent existence.

--- a/markdown/10-clearlight/03-the-journaling-prompts-of-clear-light.md
+++ b/markdown/10-clearlight/03-the-journaling-prompts-of-clear-light.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-3
+stage: 10
+chapter: 3
+order: 3
+slug: the-journaling-prompts-of-clear-light
+title: "The Journaling Prompts of Clear Light"
+content_type: chapter
+release_day: 2
+media: []
+---
+
 ## The Journaling Prompts of Clear Light
 
 At Clear Light, journaling is no longer about processing or understanding. It's about *pointing*. You're using words to gesture toward what cannot be captured in words. You're documenting the glimpses. Honoring the mystery.

--- a/markdown/10-clearlight/04-the-relationship-to-free-will-at-clear-light-adept.md
+++ b/markdown/10-clearlight/04-the-relationship-to-free-will-at-clear-light-adept.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-4
+stage: 10
+chapter: 4
+order: 4
+slug: the-relationship-to-free-will-at-clear-light-adept
+title: "The Relationship to Free Will at Clear Light: Adept"
+content_type: chapter
+release_day: 3
+media: []
+---
+
 ## The Relationship to Free Will at Clear Light: Adept
 
 At Clear Light, the question of Free Will dissolves.

--- a/markdown/10-clearlight/05-the-vibe-wavelength-of-clear-light-be-neitherall.md
+++ b/markdown/10-clearlight/05-the-vibe-wavelength-of-clear-light-be-neitherall.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-5
+stage: 10
+chapter: 5
+order: 5
+slug: the-vibe-wavelength-of-clear-light-be-neitherall
+title: "The Vibe Wavelength of Clear Light: Be (Neither/All)"
+content_type: chapter
+release_day: 4
+media: []
+---
+
 ## The Vibe Wavelength of Clear Light: Be (Neither/All)
 
 Clear Light introduces the sixth and final Mode: **Be (Neither/All)**.

--- a/markdown/10-clearlight/06-the-practice-of-clear-light-cultivating-vipassana.md
+++ b/markdown/10-clearlight/06-the-practice-of-clear-light-cultivating-vipassana.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-6
+stage: 10
+chapter: 6
+order: 6
+slug: the-practice-of-clear-light-cultivating-vipassana
+title: "The Practice of Clear Light: Cultivating Vipassana"
+content_type: chapter
+release_day: 5
+media: []
+---
+
 ## The Practice of Clear Light: Cultivating Vipassana
 
 Clear Light's practice is **Vipassana**—insight meditation. Where samatha (concentration) was about stabilizing the mind, vipassana is about *seeing* the nature of mind. Seeing the three characteristics: impermanence (*anicca*), suffering (*dukkha*), and non-self (*anatta*).

--- a/markdown/10-clearlight/07-the-archetypal-wavelength-in-clear-light-full-cycle.md
+++ b/markdown/10-clearlight/07-the-archetypal-wavelength-in-clear-light-full-cycle.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-7
+stage: 10
+chapter: 7
+order: 7
+slug: the-archetypal-wavelength-in-clear-light-full-cycle
+title: "The Archetypal Wavelength in Clear Light: Full Cycle"
+content_type: chapter
+release_day: 6
+media: []
+---
+
 ## The Archetypal Wavelength in Clear Light: Full Cycle
 
 At Clear Light, you don't transcend the Wavelength. You *master* it. You see the full cycle—Rising, Peaking, Withdrawal, Diminishing, Bottoming Out, Restoration—and you know how to work with each phase skillfully.

--- a/markdown/10-clearlight/08-after-the-ecstasy-the-laundry.md
+++ b/markdown/10-clearlight/08-after-the-ecstasy-the-laundry.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-8
+stage: 10
+chapter: 8
+order: 8
+slug: after-the-ecstasy-the-laundry
+title: "After the Ecstasy, The Laundry"
+content_type: chapter
+release_day: 7
+media: []
+---
+
 ## After the Ecstasy, The Laundry
 
 Jack Kornfield's book *After the Ecstasy, the Laundry* is essential reading for Clear Light. Because here's the truth most spiritual seekers don't want to hear:

--- a/markdown/10-clearlight/09-obstacles-are-the-path.md
+++ b/markdown/10-clearlight/09-obstacles-are-the-path.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-9
+stage: 10
+chapter: 9
+order: 9
+slug: obstacles-are-the-path
+title: "Obstacles Are the Path"
+content_type: chapter
+release_day: 8
+media: []
+---
+
 ## Obstacles Are the Path
 
 This is one of Clear Light's deepest teachings, beautifully captured in the infographics described in `ImageDescriptions.md`.

--- a/markdown/10-clearlight/10-you-cannot-stay-on-the-summit.md
+++ b/markdown/10-clearlight/10-you-cannot-stay-on-the-summit.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-10
+stage: 10
+chapter: 10
+order: 10
+slug: you-cannot-stay-on-the-summit
+title: "You Cannot Stay on the Summit"
+content_type: chapter
+release_day: 9
+media: []
+---
+
 ## You Cannot Stay on the Summit
 
 Another teaching from *After the Ecstasy, the Laundry*:

--- a/markdown/10-clearlight/11-the-practice-is-the-path.md
+++ b/markdown/10-clearlight/11-the-practice-is-the-path.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-11
+stage: 10
+chapter: 11
+order: 11
+slug: the-practice-is-the-path
+title: "The Practice IS the Path"
+content_type: chapter
+release_day: 10
+media: []
+---
+
 ## The Practice IS the Path
 
 One final teaching to close this out:

--- a/markdown/10-clearlight/12-the-90-minute-sit-the-practice-of-adepts.md
+++ b/markdown/10-clearlight/12-the-90-minute-sit-the-practice-of-adepts.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-12
+stage: 10
+chapter: 12
+order: 12
+slug: the-90-minute-sit-the-practice-of-adepts
+title: "The 90-Minute Sit: The Practice of Adepts"
+content_type: chapter
+release_day: 11
+media: []
+---
+
 ## The 90-Minute Sit: The Practice of Adepts
 
 90 minutes is not for beginners. It's not even for advanced practitioners. It's for Adepts—those who've completed the full spiral and are now deepening into mastery.

--- a/markdown/10-clearlight/13-the-bodhisattva-vow-clear-light-as-service.md
+++ b/markdown/10-clearlight/13-the-bodhisattva-vow-clear-light-as-service.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-13
+stage: 10
+chapter: 13
+order: 13
+slug: the-bodhisattva-vow-clear-light-as-service
+title: "The Bodhisattva Vow: Clear Light as Service"
+content_type: chapter
+release_day: 12
+media: []
+---
+
 ## The Bodhisattva Vow: Clear Light as Service
 
 Clear Light is where practice stops being about you and becomes about everyone.

--- a/markdown/10-clearlight/14-what-clear-light-feels-like-a-phenomenological-account.md
+++ b/markdown/10-clearlight/14-what-clear-light-feels-like-a-phenomenological-account.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-14
+stage: 10
+chapter: 14
+order: 14
+slug: what-clear-light-feels-like-a-phenomenological-account
+title: "What Clear Light Feels Like: A Phenomenological Account"
+content_type: chapter
+release_day: 13
+media: []
+---
+
 ## What Clear Light Feels Like: A Phenomenological Account
 
 Let me try to describe what it's actually like to live from Clear Light. This is phenomenology, not theory.

--- a/markdown/10-clearlight/15-the-final-integration-all-stages-always-available.md
+++ b/markdown/10-clearlight/15-the-final-integration-all-stages-always-available.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-15
+stage: 10
+chapter: 15
+order: 15
+slug: the-final-integration-all-stages-always-available
+title: "The Final Integration: All Stages, Always Available"
+content_type: chapter
+release_day: 14
+media: []
+---
+
 ## The Final Integration: All Stages, Always Available
 
 Here's the gift of Clear Light: you don't graduate past the earlier stages. You integrate them all.

--- a/markdown/10-clearlight/16-the-practice-never-ends-maintenance-and-deepening.md
+++ b/markdown/10-clearlight/16-the-practice-never-ends-maintenance-and-deepening.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-16
+stage: 10
+chapter: 16
+order: 16
+slug: the-practice-never-ends-maintenance-and-deepening
+title: "The Practice Never Ends: Maintenance and Deepening"
+content_type: chapter
+release_day: 15
+media: []
+---
+
 ## The Practice Never Ends: Maintenance and Deepening
 
 Let me be clear: Clear Light is not the finish line. It's a plateau. A stable resting place. But the practice continues.

--- a/markdown/10-clearlight/17-the-ecology-of-practice-sustaining-90-minutes-for-life.md
+++ b/markdown/10-clearlight/17-the-ecology-of-practice-sustaining-90-minutes-for-life.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-17
+stage: 10
+chapter: 17
+order: 17
+slug: the-ecology-of-practice-sustaining-90-minutes-for-life
+title: "The Ecology of Practice: Sustaining 90 Minutes for Life"
+content_type: chapter
+release_day: 16
+media: []
+---
+
 ## The Ecology of Practice: Sustaining 90 Minutes for Life
 
 Let's be practical. How do you actually maintain 90-minute sits, 4x/week, for the rest of your life?

--- a/markdown/10-clearlight/18-the-transmission-how-realization-spreads.md
+++ b/markdown/10-clearlight/18-the-transmission-how-realization-spreads.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-18
+stage: 10
+chapter: 18
+order: 18
+slug: the-transmission-how-realization-spreads
+title: "The Transmission: How Realization Spreads"
+content_type: chapter
+release_day: 17
+media: []
+---
+
 ## The Transmission: How Realization Spreads
 
 There's a phenomenon in contemplative traditions called *transmission*—the non-verbal passing of realization from teacher to student.

--- a/markdown/10-clearlight/19-three-decades-of-practice-the-long-view.md
+++ b/markdown/10-clearlight/19-three-decades-of-practice-the-long-view.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-19
+stage: 10
+chapter: 19
+order: 19
+slug: three-decades-of-practice-the-long-view
+title: "Three Decades of Practice: The Long View"
+content_type: chapter
+release_day: 18
+media: []
+---
+
 ## Three Decades of Practice: The Long View
 
 Let's zoom out. If you practice at Clear Light's dosage—90 minutes, 4x/week—for 30 years, you'll log approximately 9,360 hours.

--- a/markdown/10-clearlight/20-the-final-invitation.md
+++ b/markdown/10-clearlight/20-the-final-invitation.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-20
+stage: 10
+chapter: 20
+order: 20
+slug: the-final-invitation
+title: "The Final Invitation"
+content_type: chapter
+release_day: 19
+media: []
+---
+
 ## The Final Invitation
 
 APTITUDE has brought you here. Through Beige's grounding. Purple's receiving. Red's assertion. Blue's connection. Orange's achievement. Green's descent. Yellow's integration. Teal's witnessing. Ultraviolet's devotion. And Clear Light's radiance.

--- a/markdown/10-clearlight/21-the-90-minute-progression-a-month-by-month-guide.md
+++ b/markdown/10-clearlight/21-the-90-minute-progression-a-month-by-month-guide.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-21
+stage: 10
+chapter: 21
+order: 21
+slug: the-90-minute-progression-a-month-by-month-guide
+title: "The 90-Minute Progression: A Month-by-Month Guide"
+content_type: chapter
+release_day: 20
+media: []
+---
+
 ## The 90-Minute Progression: A Month-by-Month Guide
 
 If you're transitioning from Ultraviolet's 75 minutes to Clear Light's 90 minutes, here's how to make the leap sustainable.

--- a/markdown/10-clearlight/22-the-adepts-relationship-to-suffering.md
+++ b/markdown/10-clearlight/22-the-adepts-relationship-to-suffering.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-22
+stage: 10
+chapter: 22
+order: 22
+slug: the-adepts-relationship-to-suffering
+title: "The Adept's Relationship to Suffering"
+content_type: chapter
+release_day: 21
+media: []
+---
+
 ## The Adept's Relationship to Suffering
 
 Here's a question that arises at Clear Light: If you've touched awakening, if you've stabilized in presence, does suffering end?

--- a/markdown/10-clearlight/23-teaching-as-practice-becoming-a-holder-of-space.md
+++ b/markdown/10-clearlight/23-teaching-as-practice-becoming-a-holder-of-space.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-23
+stage: 10
+chapter: 23
+order: 23
+slug: teaching-as-practice-becoming-a-holder-of-space
+title: "Teaching as Practice: Becoming a Holder of Space"
+content_type: chapter
+release_day: 22
+media: []
+---
+
 ## Teaching as Practice: Becoming a Holder of Space
 
 At Clear Light, teaching is no longer something you "do"—it's an expression of who you are.

--- a/markdown/10-clearlight/24-the-complete-integration-living-all-ten-stages.md
+++ b/markdown/10-clearlight/24-the-complete-integration-living-all-ten-stages.md
@@ -1,3 +1,15 @@
+---
+id: clearlight-24
+stage: 10
+chapter: 24
+order: 24
+slug: the-complete-integration-living-all-ten-stages
+title: "The Complete Integration: Living All Ten Stages"
+content_type: chapter
+release_day: 23
+media: []
+---
+
 ## The Complete Integration: Living All Ten Stages
 
 Let me paint a picture of what it looks like to have full access to the entire spiral.

--- a/scripts/add_frontmatter.py
+++ b/scripts/add_frontmatter.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Add per-chapter YAML frontmatter to every stage chapter (issue #19).
+
+With bodies cleaned (#18) and the schema fixed (#17), each chapter needs the
+frontmatter block that makes the corpus machine-readable for the manifest
+generator (#20) and the app's seed.
+
+Everything except ``release_day`` is derived **mechanically** from the existing
+``markdown/<NN-stage>/<NN-slug>.md`` convention, so the metadata cannot disagree
+with the file's location:
+
+* ``stage``        = the folder's numeric prefix (1..10)
+* ``chapter``      = 1-based position within the stage (sorted by filename)
+* ``order``        = same as ``chapter``
+* ``slug``         = filename with the ``NN-`` prefix and ``.md`` stripped
+* ``id``           = ``"<stage-slug>-<chapter>"`` (e.g. ``beige-1``)
+* ``title``        = the file's first Markdown heading
+* ``content_type`` = ``chapter``
+* ``release_day``  = ``chapter - 1`` (the "daily" drip default; a human may
+                     later hand-tune this where the curriculum intends another
+                     cadence — that is the single non-mechanical knob)
+
+This script **only prepends** the block: the body bytes are asserted unchanged.
+It is idempotent — files that already begin with frontmatter are skipped.
+
+Usage::
+
+    python scripts/add_frontmatter.py            # write frontmatter in place
+    python scripts/add_frontmatter.py --check     # report only, write nothing
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MARKDOWN_DIR = REPO_ROOT / "markdown"
+
+STAGE_DIR_RE = re.compile(r"^(\d{2})-([a-z0-9]+)$")
+CHAPTER_FILE_RE = re.compile(r"^(\d{2})-(.+)\.md$")
+HEADING_RE = re.compile(r"^#{1,6}[ \t]+(.+?)[ \t]*$")
+
+
+def stage_dirs() -> list[Path]:
+    return sorted(p for p in MARKDOWN_DIR.iterdir() if p.is_dir() and STAGE_DIR_RE.match(p.name))
+
+
+def chapter_files(stage_dir: Path) -> list[Path]:
+    """Numbered section files in display order, excluding the TOC (00-...)."""
+    files = []
+    for p in stage_dir.iterdir():
+        m = CHAPTER_FILE_RE.match(p.name)
+        if m and m.group(1) != "00":  # skip 00-table-of-contents (navigational)
+            files.append(p)
+    return sorted(files, key=lambda p: p.name)
+
+
+def slug_from_filename(name: str) -> str:
+    return CHAPTER_FILE_RE.match(name).group(2)
+
+
+def title_from_body(text: str, fallback_slug: str) -> str:
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        m = HEADING_RE.match(line)
+        if m:
+            return m.group(1).strip()
+        break  # first non-empty line wasn't a heading; use the fallback
+    return fallback_slug.replace("-", " ").title()
+
+
+def yaml_quote(value: str) -> str:
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def build_frontmatter(*, id_: str, stage: int, chapter: int, slug: str,
+                      title: str, release_day: int) -> str:
+    lines = [
+        "---",
+        f"id: {id_}",
+        f"stage: {stage}",
+        f"chapter: {chapter}",
+        f"order: {chapter}",
+        f"slug: {slug}",
+        f"title: {yaml_quote(title)}",
+        "content_type: chapter",
+        f"release_day: {release_day}",
+        "media: []",
+        "---",
+        "",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="report only; write nothing")
+    args = parser.parse_args()
+
+    written: list[Path] = []
+    skipped = 0
+    failures: list[str] = []
+
+    for stage_dir in stage_dirs():
+        stage_num = int(STAGE_DIR_RE.match(stage_dir.name).group(1))
+        stage_slug = STAGE_DIR_RE.match(stage_dir.name).group(2)
+
+        for chapter, path in enumerate(chapter_files(stage_dir), start=1):
+            original = path.read_text(encoding="utf-8")
+            if original.startswith("---\n") or original.startswith("---\r\n"):
+                skipped += 1
+                continue
+
+            slug = slug_from_filename(path.name)
+            frontmatter = build_frontmatter(
+                id_=f"{stage_slug}-{chapter}",
+                stage=stage_num,
+                chapter=chapter,
+                slug=slug,
+                title=title_from_body(original, slug),
+                release_day=chapter - 1,
+            )
+            updated = frontmatter + original
+
+            # Body must be byte-for-byte unchanged — frontmatter is prepended only.
+            if updated[len(frontmatter):] != original:
+                failures.append(f"{path}: body would change (refusing to write)")
+                continue
+
+            written.append(path)
+            if not args.check:
+                path.write_text(updated, encoding="utf-8")
+
+    rel = lambda p: p.relative_to(REPO_ROOT)
+    if failures:
+        print("BODY-UNCHANGED CHECK FAILED — no files written:", file=sys.stderr)
+        for f in failures:
+            print(f"  ✗ {f}", file=sys.stderr)
+        return 1
+
+    verb = "would add" if args.check else "added"
+    print(f"{verb} frontmatter to {len(written)} chapter(s); {skipped} already had it.")
+    by_stage: dict[str, int] = {}
+    for p in written:
+        by_stage[p.parent.name] = by_stage.get(p.parent.name, 0) + 1
+    for stage in sorted(by_stage):
+        print(f"  {stage}: {by_stage[stage]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements issue #19 (spec C) of the CMS migration (epic adepthood#388). Depends on #17 (schema) and #18 (clean bodies).

## What
- Adds `scripts/add_frontmatter.py`: mechanically derives `id/stage/chapter/order/slug/title/content_type/release_day` from the folder+filename convention and the file's first heading, then **prepends** the frontmatter block.
- Adds frontmatter to **all 209 stage chapters** across the 10 stages.

## Mechanical derivation (no guessing)
| Field | Source |
|-------|--------|
| `stage` | folder numeric prefix (1–10) |
| `chapter`/`order` | 1-based position within the stage |
| `slug` | filename minus `NN-` prefix |
| `id` | `<stage-slug>-<chapter>` |
| `title` | the file's first Markdown heading |
| `content_type` | `chapter` |
| `release_day` | `chapter - 1` (daily drip default — the one human-tunable knob) |

`00-table-of-contents.md` and `README.md` are excluded (navigational, not drip-fed).

## Guarantees
- ✅ **Body bytes unchanged** — the script asserts the body is byte-for-byte identical (frontmatter is prepended only) and refuses to write otherwise.
- ✅ **Idempotent** — files already starting with frontmatter are skipped.
- ✅ 209/209 `id`s unique, `(stage,chapter)` unique, **zero** slug↔filename mismatches.

Blocks #20 (manifest generator). `summary` omitted (optional, not fabricated); `media: []` included per the CONTENT_FORMAT.md example.

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)