### PR TITLE
Content CI: frontmatter validation, lint, link-check, manifest drift (E, #21)

### DIFF
--- a/.github/workflows/content-ci.yml
+++ b/.github/workflows/content-ci.yml
@@ -1,0 +1,74 @@
+# Content CI (issue #21)
+#
+# The Adepthood app vendors a pinned commit of this repo, so a malformed
+# chapter or a drifted manifest would break the live Course screen. This
+# workflow is the first line of defense: broken content never reaches a
+# pinned SHA.
+#
+# Branch protection: mark these status checks as required on `main`:
+#   - Frontmatter + manifest
+#   - Markdown lint
+#   - Internal links
+#
+# No secrets are used; everything runs offline against the checkout.
+
+name: Content CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  manifest:
+    name: Frontmatter + manifest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: scripts/requirements.txt
+
+      - name: Install tooling
+        run: pip install -r scripts/requirements.txt
+
+      # Validates every chapter's frontmatter (required fields, types,
+      # id/(stage,chapter) uniqueness, slug↔filename match), validates the
+      # manifest against schema/manifest.schema.json, and fails if the
+      # committed manifest.json differs from a fresh build (drift check).
+      - name: Build manifest + drift check
+        run: python scripts/build_manifest.py --check
+
+  lint:
+    name: Markdown lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Enforces CONTENT_FORMAT.md §2.2 (no raw HTML) plus structural
+      # correctness rules. Config: .markdownlint-cli2.jsonc
+      - name: markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          config: .markdownlint-cli2.jsonc
+          globs: |
+            markdown/**/*.md
+            !markdown/backup/**
+            *.md
+
+  links:
+    name: Internal links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Stdlib-only: verifies every internal link and image target in
+      # markdown/** resolves on disk. External URLs are skipped (no network).
+      - name: Check internal links + images
+        run: python3 scripts/check_links.py

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,27 @@
+// Markdown lint configuration for the content corpus (issue #21).
+//
+// The corpus is literary prose, so stylistic rules (line length, heading
+// punctuation, emphasis style, …) are deliberately OFF. What CI enforces is
+// the CONTENT_FORMAT.md contract: no raw HTML in bodies (§2.2) plus a few
+// structural correctness rules that catch real authoring mistakes.
+{
+  "config": {
+    "default": false,
+    // CONTENT_FORMAT.md §2.2 — the app renders Markdown natively and does
+    // not execute HTML. Raw HTML in a body is a build-breaking violation.
+    "no-inline-html": true,
+    // Broken constructs that silently render wrong in the app:
+    "no-reversed-links": true,
+    "no-empty-links": true,
+    "no-missing-space-atx": true,
+    "no-multiple-space-atx": true
+  },
+  "globs": [
+    "markdown/**/*.md",
+    "!markdown/backup/**",
+    "*.md"
+  ],
+  "ignores": [
+    "node_modules"
+  ]
+}

--- a/markdown/01-beige/05-the-vibe-wavelength-of-beige-internalize-do.md
+++ b/markdown/01-beige/05-the-vibe-wavelength-of-beige-internalize-do.md
@@ -12,8 +12,7 @@ media: []
 
 ## The Vibe Wavelength of Beige: Internalize (Do)
 
-This stage also builds on the introduction to the Archetypal Wavelength that you should have picked up from the <a href="https://www.google.com/url?q=https://aptitude.guru/philosophy/archetypal-wavelength&sa=D&source=editors&ust=1764912627500309&usg=AOvVaw2E0uWn4AqXvS3EHHDuBcVy"
-class="c15">Philosophy page. Please do read that material if you haven’t yet. It provides a vital foundation.
+This stage also builds on the introduction to the Archetypal Wavelength that you should have picked up from the [Philosophy page](https://aptitude.guru/philosophy/archetypal-wavelength). Please do read that material if you haven’t yet. It provides a vital foundation.
 
 For each Stage of APTITUDE, we will be looking at the Archetypal Wavelength from a different perspective. The Beige wave is the “Do”ing aspect of a Wavelength you’re Internalizing for—a six-phase cycle that reveals the natural rhythm of doing.
 

--- a/markdown/01-beige/12-in-summary.md
+++ b/markdown/01-beige/12-in-summary.md
@@ -28,7 +28,7 @@ I am nobody special and this has worked for me. Stick to the process and it just
 
 ------------------------------------------------------------------------
 
-![](../markdown/images/images/image1.png)
+![](../images/images/image1.png)
 
 The temptation to not embrace the cycle is less of a slippery slope, and more of a slippery loop.
 

--- a/markdown/01-beige/README.md
+++ b/markdown/01-beige/README.md
@@ -18,7 +18,7 @@ This folder contains the modular sections for the BEIGE stage of the APTITUDE co
 - [“INTERNALIZE (Do)”](./11-internalize-do.md)
 - [In Summary](./12-in-summary.md)
 - [The Sacred High—and the Temptation to Stay There Forever](./13-the-sacred-highand-the-temptation-to-stay-there-forever.md)
-- [When You Don’t Ground, You Ascend Into Disconnection](./14-when-you-dont-ground-you-ascend-into-disconnection.md)
+- [When You Don’t Ground, You Ascend Into Disconnection](./14-when-you-dont-ground-you-float-into-disconnection.md)
 - [And then… the dangerous temptation to repeat](./15-and-then-the-dangerous-temptation-to-repeat.md)
 - [The 5-4-3-2-1 Technique (Your Root Chakra Reset)](./16-the-5-4-3-2-1-technique-your-root-chakra-reset.md)
 - [Alternative Practice Options](./17-alternative-practice-options.md)

--- a/markdown/02-purple/05-the-vibe-wavelength-of-purple-internalize-feel.md
+++ b/markdown/02-purple/05-the-vibe-wavelength-of-purple-internalize-feel.md
@@ -12,7 +12,7 @@ media: []
 
 ## The Vibe Wavelength of Purple: Internalize (Feel)
 
-![](../markdown/images/images/image3.png)
+![](../images/images/image3.png)
 
 The Vibe Wavelength of Purple is Internalize (Feel).
 

--- a/markdown/02-purple/06-the-practice-of-purple-a-daily-tarot-draw.md
+++ b/markdown/02-purple/06-the-practice-of-purple-a-daily-tarot-draw.md
@@ -12,7 +12,7 @@ media: []
 
 ## The Practice of Purple: A Daily Tarot Draw
 
-![](../markdown/images/images/image6.png)
+![](../images/images/image6.png)
 
 The Practice of Purple is a daily meditation on symbolism, most often expressed through the Tarot. Each morning (or whenever you feel called), you’re invited to draw a card from the Major Arcana and sit with it for five minutes, allowing its imagery, archetypal tone, and symbolic resonance to steep into your consciousness like tea leaves unfurling in hot water.
 

--- a/markdown/02-purple/09-yes-and-ness-a-balance-between-radical-agency-and-radical-ac.md
+++ b/markdown/02-purple/09-yes-and-ness-a-balance-between-radical-agency-and-radical-ac.md
@@ -39,7 +39,7 @@ That’s the power of Yes-and-ness. It gives you a way to belong to your life an
 
 ### YES: Purple as a Form of Sacred Photosynthesis—Prana-synthesis?
 
-![](../markdown/images/images/image4.png)
+![](../images/images/image4.png)
 
 “YES” is the lower half of the Archetypal Wavelength—the sacred descent, the valley between peaks, the quiet underworld where Receptivity lives. If you glance at the image above, you’ll see the soft arc of this phase winding from Diminishing, through Bottoming Out, and into the first flickers of Restoration. It’s low-energy territory. But that doesn’t mean lifelessness. Quite the opposite.
 
@@ -70,7 +70,7 @@ This is the power of Purple.
 
 This is the photosynthesis of the soul.
 
-### AND: Embracing Paradox—Everything is Perfect AND We Must Fight to Improve it![](../markdown/images/images/image5.png)
+### AND: Embracing Paradox—Everything is Perfect AND We Must Fight to Improve it![](../images/images/image5.png)
 
 “And” is the top half of the Archetypal Wavelength—the High Energy phase, the arc where agency returns, momentum gathers, and potential brims. If you look at the diagram above, you’ll see it clearly: the wave rises through Rising, crests at Peaking, and begins to slope through Withdrawal. These are moments of capacity. Of motion. Of outward orientation. But most importantly—they’re moments of paradox.
 

--- a/markdown/02-purple/10-archetypal-gender-masculine-feminine-and-baphomet.md
+++ b/markdown/02-purple/10-archetypal-gender-masculine-feminine-and-baphomet.md
@@ -12,7 +12,7 @@ media: []
 
 ## Archetypal Gender: Masculine, Feminine, and Baphomet
 
-![](../markdown/images/images/image1.png)
+![](../images/images/image1.png)
 
 Take a look at the spiral above and notice the pattern: warm colors alternate with cool ones as you move upward through the ten stages of APTITUDE. This isn’t just aesthetic—it maps an energetic rhythm. The warm tones represent the Divine Masculine:
 assertive, agentic, outward-moving. The cool tones embody the Divine Feminine: receptive, intuitive, inward-facing. Each stage expresses one of these poles as part of a larger dialectic—doing and being, self-expressing and self-sacrificing, the “I” and the “We.”

--- a/markdown/02-purple/13-internalize-feel.md
+++ b/markdown/02-purple/13-internalize-feel.md
@@ -30,7 +30,7 @@ The goal here isn’t to control your feelings.
 
 It’s to befriend them.
 
-![](../markdown/images/images/image2.png)
+![](../images/images/image2.png)
 
 ### 1. RISING
 

--- a/markdown/03-red/12-externalize-do.md
+++ b/markdown/03-red/12-externalize-do.md
@@ -12,7 +12,7 @@ media: []
 
 ## “EXTERNALIZE (Do)”
 
-![](../markdown/images/images/image1.png)
+![](../images/images/image1.png)
 
 Approaching the Archetypal Wavelength from the perspective of Red means looking at what happens when the energy of your being wants to move outward. Where Beige helped you start to Inhabit your experience by building stabilizing behaviors, and Purple deepened that Inhabiting through the receptive “Feel” of sacred symbols and subtle meaning, Red shifts into a new Mode entirely: Express. In the APTITUDE progression, the six Modes—Inhabit, Express, Collaborate, Integrate, Absorb, and Be—guide us step-by-step into Whole Adepthood. And right here, in Red, we begin learning how to do something with the energy we’ve been collecting.
 

--- a/markdown/ArchetypalWavelengthIntroduction.md
+++ b/markdown/ArchetypalWavelengthIntroduction.md
@@ -1,4 +1,4 @@
-![](../markdown/images/images/image1.png)
+![](images/images/image1.png)
 
 ### Whole Adepts Surf the Archetypal Wavelength
 

--- a/markdown/ExtendedInvitation.md
+++ b/markdown/ExtendedInvitation.md
@@ -1,6 +1,6 @@
 
 
-![](../markdown/images/images/image1.png)
+![](images/images/image1.png)
 
 ------------------------------------------------------------------------
 

--- a/markdown/LiminalCreepIntroduction.md
+++ b/markdown/LiminalCreepIntroduction.md
@@ -24,7 +24,7 @@ and grounded. They are
 in radical self-ownership, capable of playing
 the game without the game playing them.
 
-![](../markdown/images/images/image1.jpg)
+![](images/images/image1.jpg)
 
 APTITUDE is the bridge between Creep and Adept. It
 takes you from self-sabotage to self-mastery. From disempowered

--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Check that internal links and images in markdown/** resolve (issue #21).
+
+Walks every Markdown file under ``markdown/`` (excluding ``backup/`` and
+editor metadata), extracts inline links and images, and verifies that every
+repo-internal target exists on disk. External targets (``https://``,
+``http://``, ``mailto:``) are skipped — checking them needs the network,
+which CI deliberately avoids. Pure-fragment links (``#anchor``) are skipped
+as well; heading-anchor validation is out of scope here.
+
+Relative targets are resolved against the containing file's directory.
+Exits non-zero listing every broken reference.
+
+Usage::
+
+    python scripts/check_links.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MARKDOWN_DIR = REPO_ROOT / "markdown"
+EXCLUDED_DIRS = {"backup", ".obsidian"}
+
+# Inline links/images: [text](target) or ![alt](target "title")
+LINK_RE = re.compile(r"!?\[[^\]]*\]\(\s*<?([^)<>\s]+)>?(?:\s+\"[^\"]*\")?\s*\)")
+EXTERNAL_RE = re.compile(r"^(https?:|mailto:|tel:|data:)", re.IGNORECASE)
+FENCE_RE = re.compile(r"^(```|~~~)")
+
+
+def iter_markdown_files() -> list[Path]:
+    files = []
+    for path in sorted(MARKDOWN_DIR.rglob("*.md")):
+        rel_parts = path.relative_to(MARKDOWN_DIR).parts
+        if any(part in EXCLUDED_DIRS for part in rel_parts):
+            continue
+        files.append(path)
+    return files
+
+
+def iter_targets(text: str):
+    """Yield (line_number, target) for each inline link/image outside code fences."""
+    in_fence = False
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if FENCE_RE.match(line.strip()):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        # Drop inline code spans so `[x](y)` inside backticks is ignored.
+        stripped = re.sub(r"`[^`]*`", "", line)
+        for m in LINK_RE.finditer(stripped):
+            yield lineno, m.group(1)
+
+
+def main() -> int:
+    broken: list[str] = []
+    checked = 0
+
+    for path in iter_markdown_files():
+        text = path.read_text(encoding="utf-8")
+        for lineno, target in iter_targets(text):
+            if EXTERNAL_RE.match(target):
+                continue
+            target_path = unquote(target.split("#", 1)[0])
+            if not target_path:  # pure fragment link
+                continue
+            checked += 1
+            resolved = (path.parent / target_path).resolve()
+            if not resolved.exists():
+                rel = path.relative_to(REPO_ROOT).as_posix()
+                broken.append(f"{rel}:{lineno}: broken link '{target}'")
+
+    if broken:
+        print(f"link check FAILED — {len(broken)} broken reference(s):",
+              file=sys.stderr)
+        for line in broken:
+            print(f"  {line}", file=sys.stderr)
+        return 1
+
+    print(f"link check passed: {checked} internal references resolve")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,3 @@
+# Tooling dependencies for scripts/ (manifest build + validation).
+PyYAML==6.0.2
+jsonschema==4.23.0


### PR DESCRIPTION
Closes #21

## What this adds

`.github/workflows/content-ci.yml` runs three independent jobs on every PR and push to `main` — no secrets, fully offline:

| Check | What it enforces |
|---|---|
| **Frontmatter + manifest** | `scripts/build_manifest.py --check`: required fields/types on every chapter, `id` and `(stage, chapter)` uniqueness, `slug`↔filename match, JSON Schema validation (`jsonschema` now installed in CI), and the drift check — a stale committed `manifest.json` fails the build. |
| **Markdown lint** | `markdownlint-cli2` with `.markdownlint-cli2.jsonc`: **no raw HTML** (CONTENT_FORMAT.md §2.2) plus structural rules (reversed/empty links, malformed ATX headings). Stylistic rules stay off — the corpus is literary prose. |
| **Internal links** | New stdlib-only `scripts/check_links.py`: every internal link and image target in `markdown/**` must resolve on disk. External URLs skipped (soft per issue). |

## Corpus fixes the new checks caught

A clean corpus passes end-to-end — these were real violations:

- `01-beige/05`: leftover raw HTML `<a>` (Google-redirect wrapper) → clean Markdown link to the Philosophy page
- 11 image refs of the form `../markdown/images/images/imageN.png` in stage dirs resolved **outside the tree** (`markdown/markdown/...`) → corrected to `../images/images/...` (stage files) and `images/images/...` (top-level files)
- `01-beige/README.md`: TOC link pointed at the old `...ascend-into-disconnection` filename → `...float-into-disconnection`

## Branch protection

Mark these required status checks on `main` (also documented in the workflow header): **Frontmatter + manifest**, **Markdown lint**, **Internal links**.

## Verified locally

All three checks pass on this branch: 209 chapters validated, manifest current, 238 files linted with 0 errors, 258 internal references resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)