### PR TITLE
Media / asset handling: convention + enforcement (I, #25)

### DIFF
--- a/.github/workflows/content-ci.yml
+++ b/.github/workflows/content-ci.yml
@@ -68,7 +68,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Stdlib-only: verifies every internal link and image target in
-      # markdown/** resolves on disk. External URLs are skipped (no network).
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: scripts/requirements.txt
+
+      - name: Install tooling
+        run: pip install -r scripts/requirements.txt
+
+      # Verifies every internal link and image target in markdown/** resolves
+      # on disk, including frontmatter media[] path/poster entries (issue #25).
+      # External URLs are skipped (no network).
       - name: Check internal links + images
         run: python3 scripts/check_links.py

--- a/CONTENT_FORMAT.md
+++ b/CONTENT_FORMAT.md
@@ -213,29 +213,93 @@ curricular intent, unlike `stage`/`chapter`/`order`/`slug` which are mechanical.
 
 ---
 
-## 6. Media & assets (summary)
+## 6. Media & assets
 
-> The full convention is specified in issue
-> [#25](https://github.com/Geoffe-Ga/aptitude-course/issues/25) and will be
-> expanded in this section. The contract below is the agreed shape.
+> Canonical per issue [#25](https://github.com/Geoffe-Ga/aptitude-course/issues/25).
+> App-side resolution pairs with
+> [adepthood#394](https://github.com/Geoffe-Ga/adepthood/issues/394) (native
+> Markdown rendering).
 
-- **Images** are committed in-repo under `markdown/<NN-stage>/assets/` and
-  referenced with **repo-relative paths** in Markdown
-  (`![alt](assets/diagram.png)`), so they vendor into the app image with the
-  content — no runtime network fetch.
-- **Video / large media** is referenced from frontmatter `media[]` rather than
-  embedded inline:
+### 6.1 Where assets live
 
-  ```yaml
-  media:
-    - type: video           # video | image | audio
-      url: https://cdn.example.com/beige-intro.mp4
-      poster: assets/beige-intro-poster.png   # optional
-      caption: "Beige introduction"            # optional
-  ```
+| Kind | Storage | Referenced via |
+|------|---------|----------------|
+| **Images** (and other small media) | Committed **in-repo** under `markdown/<NN-stage>/assets/` | Inline Markdown image with a **file-relative path**: `![alt](assets/diagram.png)` |
+| **Video / large media** | **External** stable URL (CDN, hosting bucket) — never committed | Frontmatter `media[]` entry with `url:` (§6.3) — never embedded inline |
 
-- The manifest generator (#20) validates `media[]`; the CI link-check (#21)
-  verifies repo-relative asset paths resolve.
+**Size thresholds.** Commit an asset in-repo (Option A) when it is an image
+or audio clip **≤ 2 MB**; use an external URL (Option B) for any video, and
+for any single asset **> 10 MB**. Between 2–10 MB, prefer compressing into
+Option A; go external only when quality genuinely requires the bytes. The
+intent: the corpus (and therefore the app image that vendors it) stays small
+enough to ship, and rendering chapters never requires a network fetch except
+for streaming video.
+
+**Legacy location.** Pre-pipeline images live under `markdown/images/` and
+are referenced with file-relative paths (e.g. `../images/images/image1.png`
+from a stage directory). This location remains valid — the link-check
+verifies it — but **new** assets go in the per-stage `assets/` directories,
+and legacy images should migrate there as the referencing chapters get
+touched.
+
+### 6.2 Referencing assets from Markdown bodies
+
+- Use a standard Markdown image with a path **relative to the referencing
+  file**: from `markdown/01-beige/03-foo.md`, write
+  `![Wavelength diagram](assets/wavelength.png)` for
+  `markdown/01-beige/assets/wavelength.png`.
+- Always supply meaningful alt text.
+- Never use raw HTML (`<img>`, `<video>`, `<iframe>`) — §2.2 applies; CI
+  rejects it.
+- External images by URL are allowed but discouraged (they reintroduce a
+  runtime network dependency); prefer committing them.
+
+### 6.3 The `media[]` frontmatter shape
+
+Non-inline media (video, downloadable audio, a gallery image the app should
+present specially) is declared in frontmatter:
+
+```yaml
+media:
+  - type: video            # required: video | image | audio
+    url: https://cdn.example.com/beige-intro.mp4   # url OR path required
+    poster: assets/beige-intro-poster.png          # optional, repo-committed
+    caption: "Beige introduction"                  # optional
+  - type: image
+    path: assets/altar-setup.png                   # in-repo alternative to url
+```
+
+Field rules (enforced by the manifest build and
+`schema/manifest.schema.json`):
+
+| Field | Required | Rule |
+|-------|----------|------|
+| `type` | yes | One of `video`, `image`, `audio`. |
+| `url` / `path` | exactly one | `url` is an absolute `https://` URL (Option B). `path` is file-relative to the chapter (Option A) and must resolve on disk. |
+| `poster` | no | File-relative path to a committed image; must resolve on disk. |
+| `caption` | no | Plain text shown with the media. |
+
+### 6.4 Validation
+
+- **Manifest build** (`scripts/build_manifest.py`, CI job *Frontmatter +
+  manifest*): validates every `media[]` entry's shape — known `type`, exactly
+  one of `url`/`path`, `https://` URLs — and fails the build otherwise.
+- **Link-check** (`scripts/check_links.py`, CI job *Internal links*):
+  verifies every inline image/link target **and** every relative
+  `media[].path`/`media[].poster` resolves on disk.
+
+### 6.5 How the app resolves asset paths
+
+The app vendors this repo at a pinned SHA into its backend image
+(`backend/content/**`, see [CONSUMPTION.md](./CONSUMPTION.md) §1/§4) and
+serves committed assets from a static route over that directory. A relative
+reference is resolved **against the referencing file's directory** — the same
+rule this repo's link-check uses — then mapped onto the static route. So
+`assets/diagram.png` inside `markdown/01-beige/03-foo.md` is served from
+`<static-root>/markdown/01-beige/assets/diagram.png`. `media[].url` entries
+are streamed directly by the client. The concrete route lives app-side and is
+owned by adepthood#394; the contract this repo guarantees is only that
+relative paths resolve within the repo tree at the pinned SHA.
 
 ---
 

--- a/scripts/build_manifest.py
+++ b/scripts/build_manifest.py
@@ -146,6 +146,35 @@ def validate(chapters: list[dict]) -> None:
                 f"duplicate (stage,chapter)={key} in {path} and {seen_stage_chapter[key]}")
         seen_stage_chapter[key] = path
 
+        validate_media(c["media"], path)
+
+
+MEDIA_TYPES = {"video", "image", "audio"}
+
+
+def validate_media(media, path: str) -> None:
+    """Validate media[] shape per CONTENT_FORMAT.md §6.3 (issue #25)."""
+    if not isinstance(media, list):
+        raise ManifestError(f"{path}: media must be a list")
+    for i, item in enumerate(media):
+        where = f"{path}: media[{i}]"
+        if not isinstance(item, dict):
+            raise ManifestError(f"{where}: must be a mapping")
+        unknown = set(item) - {"type", "url", "path", "poster", "caption"}
+        if unknown:
+            raise ManifestError(f"{where}: unknown field(s) {sorted(unknown)}")
+        if item.get("type") not in MEDIA_TYPES:
+            raise ManifestError(
+                f"{where}: type must be one of {sorted(MEDIA_TYPES)}")
+        has_url, has_path = "url" in item, "path" in item
+        if has_url == has_path:
+            raise ManifestError(f"{where}: exactly one of url/path is required")
+        if has_url and not str(item["url"]).startswith("https://"):
+            raise ManifestError(f"{where}: url must be an absolute https:// URL")
+        for field in ("path", "poster", "caption"):
+            if field in item and not isinstance(item[field], str):
+                raise ManifestError(f"{where}: {field} must be a string")
+
 
 def validate_against_schema(manifest: dict) -> str:
     """Validate with jsonschema if available; otherwise note it was skipped."""

--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -8,6 +8,9 @@ repo-internal target exists on disk. External targets (``https://``,
 which CI deliberately avoids. Pure-fragment links (``#anchor``) are skipped
 as well; heading-anchor validation is out of scope here.
 
+Frontmatter ``media[]`` entries are checked too (issue #25): every relative
+``path``/``poster`` must resolve on disk.
+
 Relative targets are resolved against the containing file's directory.
 Exits non-zero listing every broken reference.
 
@@ -22,6 +25,11 @@ import re
 import sys
 from pathlib import Path
 from urllib.parse import unquote
+
+try:
+    import yaml
+except ImportError:  # media[] checks need PyYAML (scripts/requirements.txt)
+    yaml = None
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MARKDOWN_DIR = REPO_ROOT / "markdown"
@@ -58,12 +66,40 @@ def iter_targets(text: str):
             yield lineno, m.group(1)
 
 
+def iter_media_targets(text: str):
+    """Yield (label, target) for relative media[] path/poster entries (issue #25)."""
+    if yaml is None or not text.startswith("---"):
+        return
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return
+    try:
+        fm = yaml.safe_load(parts[1]) or {}
+    except yaml.YAMLError:
+        return  # malformed frontmatter is the manifest build's failure to report
+    media = fm.get("media")
+    if not isinstance(media, list):
+        return
+    for i, item in enumerate(media):
+        if not isinstance(item, dict):
+            continue
+        for field in ("path", "poster"):
+            value = item.get(field)
+            if isinstance(value, str) and value and not EXTERNAL_RE.match(value):
+                yield f"media[{i}].{field}", value
+
+
 def main() -> int:
     broken: list[str] = []
     checked = 0
 
+    if yaml is None:
+        print("warning: PyYAML not installed — skipping media[] checks",
+              file=sys.stderr)
+
     for path in iter_markdown_files():
         text = path.read_text(encoding="utf-8")
+        rel = path.relative_to(REPO_ROOT).as_posix()
         for lineno, target in iter_targets(text):
             if EXTERNAL_RE.match(target):
                 continue
@@ -73,8 +109,11 @@ def main() -> int:
             checked += 1
             resolved = (path.parent / target_path).resolve()
             if not resolved.exists():
-                rel = path.relative_to(REPO_ROOT).as_posix()
                 broken.append(f"{rel}:{lineno}: broken link '{target}'")
+        for label, target in iter_media_targets(text):
+            checked += 1
+            if not (path.parent / target).resolve().exists():
+                broken.append(f"{rel}: {label}: broken asset path '{target}'")
 
     if broken:
         print(f"link check FAILED — {len(broken)} broken reference(s):",


### PR DESCRIPTION
Closes #25

## What this adds

**CONTENT_FORMAT.md §6** is now the full asset convention rather than a summary stub:

- **§6.1 Storage**: Option A — images/small media committed under `markdown/<NN-stage>/assets/`; Option B — video and anything >10 MB referenced by stable external URL in `media[]`. Size thresholds documented (≤2 MB commit; 2–10 MB compress-then-commit; >10 MB / video external). Legacy `markdown/images/` location grandfathered with a migrate-as-touched policy.
- **§6.2 Reference convention**: standard Markdown images with file-relative paths, alt text required, no raw HTML (`<img>`/`<video>`/`<iframe>` rejected by lint).
- **§6.3 `media[]` shape**: `type` (video|image|audio), exactly one of `url` (https only) / `path` (in-repo), optional `poster`/`caption` — matching `schema/manifest.schema.json`'s `media_item`.
- **§6.5 App-side resolution**: relative paths resolve against the referencing file's directory, mapped onto the app's static route over the vendored tree — concrete route owned by adepthood#394 (cross-linked).

**Enforcement** (acceptance criteria):

- `build_manifest.py` now validates `media[]` shape with built-in checks (fails loudly; previously only the optional jsonschema pass covered it).
- `check_links.py` now resolves `media[].path` and `media[].poster` from frontmatter, in addition to inline links/images. The CI links job installs `scripts/requirements.txt` for PyYAML.

## Verified

Clean corpus passes all three checks. Negative tests confirmed both new validators fire: a `media` entry missing `url`/`path` fails the manifest build with a precise error, and a non-resolving `poster:` fails the link check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)