### PR TITLE
Migrate site-resource pages into the repo (G, #23)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,11 +93,11 @@ All authoritative stage specifications live in `google_docs/database_of_course_c
 
 ### Supporting Materials
 
-- `markdown/APTITUDELandingPage.md` - Course introduction
-- `markdown/APTITUDEStagesDeepDive.md` - Overview of all 10 stages
-- `markdown/ArchetypalWavelengthIntroduction.md` - Wavelength theory
+- `markdown/resources/about.md` - Course introduction
+- `markdown/resources/aptitude-stages.md` - Overview of all 10 stages
+- `markdown/resources/archetypal-wavelength.md` - Wavelength theory
 - `markdown/ExtendedInvitation.md` - Enrollment/philosophy
-- `markdown/LiminalCreepIntroduction.md` - Target audience definition
+- `markdown/resources/liminal-creep.md` - Target audience definition
 - `markdown/meta/metrics.md` - Auto-generated repository statistics
 
 ### Content Source Pipeline

--- a/README.md
+++ b/README.md
@@ -59,11 +59,8 @@ APTITUDE/
 │   ├── 08-teal/ (25 sections)
 │   ├── 09-ultraviolet/ (22 sections)
 │   ├── 10-clearlight/ (25 sections)
-│   ├── APTITUDELandingPage.md
-│   ├── APTITUDEStagesDeepDive.md
-│   ├── ArchetypalWavelengthIntroduction.md
+│   ├── resources/             # Site-resource pages (about, stages, wavelength, liminal-creep)
 │   ├── ExtendedInvitation.md
-│   ├── LiminalCreepIntroduction.md
 │   └── meta/
 │       └── metrics.md (repository statistics)
 ├── google_docs/
@@ -158,8 +155,8 @@ There is no spiritual retirement. There is no enlightenment you can rest in fore
 
 ## Get Started
 
-1. **Read the Landing Page**: `markdown/APTITUDELandingPage.md`
-2. **Understand the Wavelength**: `markdown/ArchetypalWavelengthIntroduction.md`
+1. **Read the Landing Page**: `markdown/resources/about.md`
+2. **Understand the Wavelength**: `markdown/resources/archetypal-wavelength.md`
 3. **Begin with Beige**: `markdown/01-beige/README.md`
 4. **Move through the stages** at your own pace (recommended: 3-4 weeks per stage)
 

--- a/manifest.json
+++ b/manifest.json
@@ -2510,5 +2510,34 @@
       "path": "markdown/10-clearlight/24-the-complete-integration-living-all-ten-stages.md"
     }
   ],
-  "site_resources": []
+  "site_resources": [
+    {
+      "slug": "about",
+      "title": "APTITUDE Intro",
+      "description": "Welcome to the APTITUDE Course: what Adepthood is and what the course offers.",
+      "media": [],
+      "path": "markdown/resources/about.md"
+    },
+    {
+      "slug": "aptitude-stages",
+      "title": "APTITUDE Stages",
+      "description": "A deep dive into the ten stages of Adepthood, from Beige to Clear Light.",
+      "media": [],
+      "path": "markdown/resources/aptitude-stages.md"
+    },
+    {
+      "slug": "archetypal-wavelength",
+      "title": "Archetypal Wavelength Intro",
+      "description": "The six-phase wave underlying every cycle, and how Whole Adepts surf it.",
+      "media": [],
+      "path": "markdown/resources/archetypal-wavelength.md"
+    },
+    {
+      "slug": "liminal-creep",
+      "title": "Who Benefits?",
+      "description": "From Liminal Creep to Whole Adept: who this course is for.",
+      "media": [],
+      "path": "markdown/resources/liminal-creep.md"
+    }
+  ]
 }

--- a/markdown/01-beige/README.md
+++ b/markdown/01-beige/README.md
@@ -27,7 +27,7 @@ This folder contains the modular sections for the BEIGE stage of the APTITUDE co
 ## Navigation
 
 - **Next Stage**: [Stage 2](../02-purple/)
-- **Course Overview**: [../APTITUDEStagesDeepDive.md](../APTITUDEStagesDeepDive.md)
+- **Course Overview**: [APTITUDE Stages Deep Dive](../resources/aptitude-stages.md)
 
 ## Source
 

--- a/markdown/02-purple/README.md
+++ b/markdown/02-purple/README.md
@@ -25,7 +25,7 @@ This folder contains the modular sections for the PURPLE stage of the APTITUDE c
 
 - **Previous Stage**: [Stage 1](../01-beige/)
 - **Next Stage**: [Stage 3](../03-red/)
-- **Course Overview**: [../APTITUDEStagesDeepDive.md](../APTITUDEStagesDeepDive.md)
+- **Course Overview**: [APTITUDE Stages Deep Dive](../resources/aptitude-stages.md)
 
 ## Source
 

--- a/markdown/03-red/README.md
+++ b/markdown/03-red/README.md
@@ -24,7 +24,7 @@ This folder contains the modular sections for the RED stage of the APTITUDE cour
 
 - **Previous Stage**: [Stage 2](../02-purple/)
 - **Next Stage**: [Stage 4](../04-blue/)
-- **Course Overview**: [../APTITUDEStagesDeepDive.md](../APTITUDEStagesDeepDive.md)
+- **Course Overview**: [APTITUDE Stages Deep Dive](../resources/aptitude-stages.md)
 
 ## Source
 

--- a/markdown/04-blue/README.md
+++ b/markdown/04-blue/README.md
@@ -24,7 +24,7 @@ This folder contains the modular sections for the BLUE stage of the APTITUDE cou
 
 - **Previous Stage**: [Stage 3](../03-red/)
 - **Next Stage**: [Stage 5](../05-orange/)
-- **Course Overview**: [../APTITUDEStagesDeepDive.md](../APTITUDEStagesDeepDive.md)
+- **Course Overview**: [APTITUDE Stages Deep Dive](../resources/aptitude-stages.md)
 
 ## Source
 

--- a/markdown/05-orange/README.md
+++ b/markdown/05-orange/README.md
@@ -39,7 +39,7 @@ This folder contains the modular sections for the ORANGE stage of the APTITUDE c
 
 - **Previous Stage**: [Stage 4](../04-blue/)
 - **Next Stage**: [Stage 6](../06-green/)
-- **Course Overview**: [../APTITUDEStagesDeepDive.md](../APTITUDEStagesDeepDive.md)
+- **Course Overview**: [APTITUDE Stages Deep Dive](../resources/aptitude-stages.md)
 
 ## Source
 

--- a/markdown/06-green/README.md
+++ b/markdown/06-green/README.md
@@ -34,7 +34,7 @@ This folder contains the modular sections for the GREEN stage of the APTITUDE co
 
 - **Previous Stage**: [Stage 5](../05-orange/)
 - **Next Stage**: [Stage 7](../07-yellow/)
-- **Course Overview**: [../APTITUDEStagesDeepDive.md](../APTITUDEStagesDeepDive.md)
+- **Course Overview**: [APTITUDE Stages Deep Dive](../resources/aptitude-stages.md)
 
 ## Source
 

--- a/markdown/07-yellow/README.md
+++ b/markdown/07-yellow/README.md
@@ -36,7 +36,7 @@ This folder contains the modular sections for the YELLOW stage of the APTITUDE c
 
 - **Previous Stage**: [Stage 6](../06-green/)
 - **Next Stage**: [Stage 8](../08-teal/)
-- **Course Overview**: [../APTITUDEStagesDeepDive.md](../APTITUDEStagesDeepDive.md)
+- **Course Overview**: [APTITUDE Stages Deep Dive](../resources/aptitude-stages.md)
 
 ## Source
 

--- a/markdown/08-teal/README.md
+++ b/markdown/08-teal/README.md
@@ -34,7 +34,7 @@ This folder contains the modular sections for the TEAL stage of the APTITUDE cou
 
 - **Previous Stage**: [Stage 7](../07-yellow/)
 - **Next Stage**: [Stage 9](../09-ultraviolet/)
-- **Course Overview**: [../APTITUDEStagesDeepDive.md](../APTITUDEStagesDeepDive.md)
+- **Course Overview**: [APTITUDE Stages Deep Dive](../resources/aptitude-stages.md)
 
 ## Source
 

--- a/markdown/09-ultraviolet/README.md
+++ b/markdown/09-ultraviolet/README.md
@@ -31,7 +31,7 @@ This folder contains the modular sections for the ULTRAVIOLET stage of the APTIT
 
 - **Previous Stage**: [Stage 8](../08-teal/)
 - **Next Stage**: [Stage 10](../10-clearlight/)
-- **Course Overview**: [../APTITUDEStagesDeepDive.md](../APTITUDEStagesDeepDive.md)
+- **Course Overview**: [APTITUDE Stages Deep Dive](../resources/aptitude-stages.md)
 
 ## Source
 

--- a/markdown/10-clearlight/README.md
+++ b/markdown/10-clearlight/README.md
@@ -33,7 +33,7 @@ This folder contains the modular sections for the CLEARLIGHT stage of the APTITU
 ## Navigation
 
 - **Previous Stage**: [Stage 9](../09-ultraviolet/)
-- **Course Overview**: [../APTITUDEStagesDeepDive.md](../APTITUDEStagesDeepDive.md)
+- **Course Overview**: [APTITUDE Stages Deep Dive](../resources/aptitude-stages.md)
 
 ## Source
 

--- a/markdown/resources/about.md
+++ b/markdown/resources/about.md
@@ -1,3 +1,11 @@
+---
+slug: about
+title: "APTITUDE Intro"
+content_type: essay
+description: "Welcome to the APTITUDE Course: what Adepthood is and what the course offers."
+media: []
+---
+
 Welcome to the APTITUDE Course
 
 Adepthood is what comes after adulthood, but only for those who choose

--- a/markdown/resources/aptitude-stages.md
+++ b/markdown/resources/aptitude-stages.md
@@ -1,3 +1,10 @@
+---
+slug: aptitude-stages
+title: "APTITUDE Stages"
+content_type: essay
+description: "A deep dive into the ten stages of Adepthood, from Beige to Clear Light."
+media: []
+---
 
 ### The Ten Stages of Adepthood
 
@@ -30,11 +37,11 @@ Onward. Ever onward.
 One way to take the course is to
 decide on your own
 habits, and I‘ll introduce a process for picking
-the right ones—what [Charles Duhigg](https://www.google.com/url?q=https://charlesduhigg.com/the-power-of-habit/&sa=D&source=editors&ust=1764912760084491&usg=AOvVaw1Fr5GSHS-MGQ6T92jU-pH4) called “keystone
+the right ones—what [Charles Duhigg](https://charlesduhigg.com/the-power-of-habit/) called “keystone
 habits.” Like the one rock that holds up an entire bridge, these are the
 small changes that can shift your entire pattern of behavior.
 
-We’ll also be discussing [James Clear](https://www.google.com/url?q=https://jamesclear.com/atomic-habits&sa=D&source=editors&ust=1764912760084827&usg=AOvVaw01XUaFCwGNmRDBRz3Hq-rI)’s four-fold strategy
+We’ll also be discussing [James Clear](https://jamesclear.com/atomic-habits)’s four-fold strategy
 for building habits that relies of manifesting
 an Aspiration
 Identity that
@@ -99,8 +106,8 @@ Wholeness.
 
 Their colors are borrowed—and
 modified to refer specifically to Aspects of
-Free Will—from [Clare Graves’](https://www.google.com/url?q=https://www.clarewgraves.com/home.html&sa=D&source=editors&ust=1764912760089856&usg=AOvVaw3NEnCLsUb-yEdRPp-GK84w) Spiral Dynamics
-and Ken Wilber’s [Growing Up](https://www.google.com/url?q=https://integrallife.com/growing-up-a-guided-tour/&sa=D&source=editors&ust=1764912760090030&usg=AOvVaw0Dxp4zX_WieHsXyESxGX4d) stages. While the
+Free Will—from [Clare Graves’](https://www.clarewgraves.com/home.html) Spiral Dynamics
+and Ken Wilber’s [Growing Up](https://integrallife.com/growing-up-a-guided-tour/) stages. While the
 color codes may seem cryptic, don’t get too tripped up. They don’t
 correspond to chakras, political parties, cultures, or anything else,
 really.
@@ -129,7 +136,7 @@ Name, followed by its Color, Theme, and Archetype in parentheses.
 In the beginning I was almost like an automaton,
 thoughtlessly performing the actions that would keep me alive.
 
-~ Patrick Rothfuss, [Name of the Wind](https://www.google.com/url?q=https://patrickrothfuss.com/content/books.html&sa=D&source=editors&ust=1764912760092470&usg=AOvVaw2Ltgx-qxvNi3Jb-4TQJhZh)
+~ Patrick Rothfuss, [Name of the Wind](https://patrickrothfuss.com/content/books.html)
 
 At this foundational level, individuals operate purely
 from instinct, driven by survival needs alone. There is no awareness of
@@ -161,7 +168,7 @@ exercising agency.
 I'll make believe you are who you think you are if you
 make believe I am who I think I am.
 
-~ [Ram Dass](https://www.google.com/url?q=https://beherenownetwork.com/category/ram-dass/&sa=D&source=editors&ust=1764912760095158&usg=AOvVaw3VryZoiMGrimEspoS3h5jh)
+~ [Ram Dass](https://beherenownetwork.com/category/ram-dass/)
 
 As we evolve, our personalities take shape through the
 influence of cultural and mythical archetypes. We model ourselves after
@@ -194,7 +201,7 @@ that which enriches the physical form.
 If we truly loved ourselves, we would never harm
 another because we are all interconnected.
 
-~ Sharon Salzberg, [Lovingkindness](https://www.google.com/url?q=https://www.sharonsalzberg.com/lovingkindness&sa=D&source=editors&ust=1764912760097124&usg=AOvVaw17QCT4CspbFeFazNGUCVgH)
+~ Sharon Salzberg, [Lovingkindness](https://www.sharonsalzberg.com/lovingkindness)
 
 Here, behavior is driven by an often unconscious urge
 to alleviate emotional pain. Without self-love, the tendency is to exert
@@ -248,7 +255,7 @@ Like I'm close to something real
 I wanna find something I've wanted all along:
 Somewhere I belong
 
-~ Linkin Park, [Somewhere I Belong](https://www.google.com/url?q=https://linkinpark.com&sa=D&source=editors&ust=1764912760100240&usg=AOvVaw1cb2hdH2Sc4TqKAalfs5NI)
+~ Linkin Park, [Somewhere I Belong](https://linkinpark.com)
 
 This stage is defined by external expectations. People
 behave according to their roles in relationships and society, seeing
@@ -292,7 +299,7 @@ worse.
 Do you want a song of glory?
 Well I'm fucking screaming… at you
 
-~ The Used, [A Box Full of Sharp Objects](https://www.google.com/url?q=https://theused.net&sa=D&source=editors&ust=1764912760103598&usg=AOvVaw0nbR9cSf9M6DhAEY9jt1lb)
+~ The Used, [A Box Full of Sharp Objects](https://theused.net)
 
 Here, individuals chase external validation:
 achievement, money, status, and recognition. Free Will is still largely
@@ -328,11 +335,11 @@ Each thing has its own intrinsic value
 And is related to everything else in function and position.
 
 ~ Eihei Dogen, The Song of the Precious Mirror Samadhi
-(via Deborah Eden Tull, quoted in [Luminous Darkness](https://www.google.com/url?q=https://www.deborahedentull.com/luminous-darkness&sa=D&source=editors&ust=1764912760105420&usg=AOvVaw1u7W4oWcx8ME7iDN9SqBxM))
+(via Deborah Eden Tull, quoted in [Luminous Darkness](https://www.deborahedentull.com/luminous-darkness))
 
 Pluralistic thinking emerges here, where fairness,
 inclusivity, and moral virtue become priorities. This is a stage when
-the venerable [bell hooks](https://www.google.com/url?q=https://bellhooksbooks.com/&sa=D&source=editors&ust=1764912760105689&usg=AOvVaw2aHUUbtsSoVrAZpKqOpBrN)’ rightly decried
+the venerable [bell hooks](https://bellhooksbooks.com/)’ rightly decried
 hegemony, “Colonialist, White-Supremacist, Capitalist Patriarchy,” is
 the villain oppressing the edges that we now wish to center. It seems
 that single-mindedly opposing that dominator power structure is the only
@@ -376,7 +383,7 @@ can coexist… But—and this is the incredibly important point—put all the
 scientific results together, from all the relevant scientific
 disciplines, and there’s no room for free will.
 
-~ Robert Sapolsky, [Determined](https://www.google.com/url?q=https://humsci.stanford.edu/feature/determined-science-life-without-free-will-robert-m-sapolsky-biology&sa=D&source=editors&ust=1764912760108103&usg=AOvVaw2K3k_BWs0rYrRokHNHCCxU)
+~ Robert Sapolsky, [Determined](https://humsci.stanford.edu/feature/determined-science-life-without-free-will-robert-m-sapolsky-biology)
 
 At this Integrative stage, individuals begin to see the
 totality of their conditioning—biological, cultural, psychological. The
@@ -422,7 +429,7 @@ Make the smallest distinction, however,
 and heaven and earth are set infinitely apart.
 
 ~ [The Third Chinese Patriarch of Zen, Hsin Hsin Ming by
-Seng-T'san](https://www.google.com/url?q=https://home.csulb.edu/~wweinste/HsinHsinMing.html&sa=D&source=editors&ust=1764912760110337&usg=AOvVaw2LoqNdktVK_Wc2xGPrmGrd)
+Seng-T'san](https://home.csulb.edu/~wweinste/HsinHsinMing.html)
 
 With enough continued perseverance, the next stage helps you connect with your True Self—the transcendent aspect of you that exists beyond personality and conditioning.
 
@@ -463,7 +470,7 @@ their own agenda.
 
 We are as gods. We might as well become good at it.
 
-~ [Stuart Brand](https://www.google.com/url?q=https://www.weareasgods.film&sa=D&source=editors&ust=1764912760112374&usg=AOvVaw1MZ2pHia-Nv8XnW1bWBn2x)
+~ [Stuart Brand](https://www.weareasgods.film)
 
 That whole Free Will experience didn’t really last
 long, did it?
@@ -535,7 +542,7 @@ We all know that after the honeymoon comes the
 marriage... In spiritual life it is the same: After the ecstasy comes
 the laundry.
 
-~ Jack Kornfield, [After the Ecstasy the Laundry](https://www.google.com/url?q=https://jackkornfield.com/after-the-ecstasy-the-laundry/&sa=D&source=editors&ust=1764912760117241&usg=AOvVaw1xvAo4kUwWU3pkq9aRgdcS)
+~ Jack Kornfield, [After the Ecstasy the Laundry](https://jackkornfield.com/after-the-ecstasy-the-laundry/)
 
 At the culmination of APTITUDE, we explore how the
 illusion of an individual separate from the cosmos might disappear.

--- a/markdown/resources/archetypal-wavelength.md
+++ b/markdown/resources/archetypal-wavelength.md
@@ -1,4 +1,12 @@
-![](images/images/image1.png)
+---
+slug: archetypal-wavelength
+title: "Archetypal Wavelength Intro"
+content_type: essay
+description: "The six-phase wave underlying every cycle, and how Whole Adepts surf it."
+media: []
+---
+
+![](../images/images/image1.png)
 
 ### Whole Adepts Surf the Archetypal Wavelength
 
@@ -57,7 +65,7 @@ Granted, as with most Ken Wilber-style Integral theories, sometimes you
 have to squint your eyes a bit—and yet,
 everything seems to fit.
 
-[Wilber founded Integral Philosophy](https://www.google.com/url?q=https://kenwilber.com/&sa=D&source=editors&ust=1764912844304192&usg=AOvVaw2upgwlHK2CcJoOKXhGnV4Z) to
+[Wilber founded Integral Philosophy](https://kenwilber.com/) to
 describe the similarities between the core tenets of an incredibly wide
 spectrum of intellectual, spiritual and social arenas. Working like a
 madman locked in his house with pages and pages of handwritten notes
@@ -109,7 +117,7 @@ alternation of gain and loss, pleasure and pain. For each of us, even
 the Buddha, it is only by letting go into this truth that we awaken to
 that which is timeless, the reality of freedom.
 
-~ Jack Kornfield, [After the Ecstasy the Laundry](https://www.google.com/url?q=https://jackkornfield.com/after-the-ecstasy-the-laundry/&sa=D&source=editors&ust=1764912844308245&usg=AOvVaw0SJ1Ome0gDbQPWGrxnOEVB)
+~ Jack Kornfield, [After the Ecstasy the Laundry](https://jackkornfield.com/after-the-ecstasy-the-laundry/)
 
 #### Rising
 

--- a/markdown/resources/liminal-creep.md
+++ b/markdown/resources/liminal-creep.md
@@ -1,7 +1,15 @@
+---
+slug: liminal-creep
+title: "Who Benefits?"
+content_type: essay
+description: "From Liminal Creep to Whole Adept: who this course is for."
+media: []
+---
+
 ### From Liminal Creep to Whole Adept: Transformation Made Possible by APTITUDE
 
-You know the [Creep archetype](https://www.google.com/url?q=https://creekmasons.com/p/im-a-creep&sa=D&source=editors&ust=1764912924390900&usg=AOvVaw0O4ds30GBvo0qRtgbiv-Et). A touch of
-loving self-deprecation inspired by [Radiohead](https://www.google.com/url?q=https://www.youtube.com/watch?v%3DXFkzRNyygfk&sa=D&source=editors&ust=1764912924391036&usg=AOvVaw0mpteUohUlokmzvjtmrDVQ), because I want to
+You know the [Creep archetype](https://creekmasons.com/p/im-a-creep). A touch of
+loving self-deprecation inspired by [Radiohead](https://www.youtube.com/watch?v=XFkzRNyygfk), because I want to
 ”have the perfect body” and “perfect soul” so I can finally “belong
 here.” You know this archetype—because you’ve
 been the Creep.
@@ -24,7 +32,7 @@ and grounded. They are
 in radical self-ownership, capable of playing
 the game without the game playing them.
 
-![](images/images/image1.jpg)
+![](../images/images/image1.jpg)
 
 APTITUDE is the bridge between Creep and Adept. It
 takes you from self-sabotage to self-mastery. From disempowered


### PR DESCRIPTION
Closes #23

## What this does

The four public pages the app's "From Aptitude Guru" chips map to now live in `markdown/resources/` as clean Markdown with frontmatter, and `manifest.json` emits them under `site_resources[]`:

| Slug (unchanged, app keys on these) | Title | Source file (moved) |
|---|---|---|
| `about` | APTITUDE Intro | `APTITUDELandingPage.md` |
| `aptitude-stages` | APTITUDE Stages | `APTITUDEStagesDeepDive.md` |
| `archetypal-wavelength` | Archetypal Wavelength Intro | `ArchetypalWavelengthIntroduction.md` |
| `liminal-creep` | Who Benefits? | `LiminalCreepIntroduction.md` |

Details:

- Frontmatter: `slug`, `title`, `content_type: essay`, `description`, `media: []` — **no** `stage`/`release_day` (not stage-gated), per the issue and CONTENT_FORMAT.md §5.1.
- Filenames are `<slug>.md`, so the existing app surface is unchanged.
- Cleanup while porting: unwrapped all Google-Docs redirect URLs (`google.com/url?q=…`) to their direct targets; image refs adjusted for the new directory depth.
- Inbound references fixed: all 10 stage `README.md` "Course Overview" links, plus `README.md` (tree + getting-started) and `CLAUDE.md` paths. `ExtendedInvitation.md` stays top-level (not one of the four).
- `manifest.json` regenerated: **209 chapters, 4 site resources**; bodies render with the same dialect as chapters (lint + link checks pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)