### PR TITLE
Purple alternative practices: receptivity meditations, not divination (#14)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -295,7 +295,7 @@
       "chapter": 7,
       "order": 7,
       "slug": "alternative-practice-examples-i-ching-traffic-lights-bibliom",
-      "title": "Alternative Practice Examples: I-Ching, Traffic Lights, Bibliomancy, Synchronicity",
+      "title": "Alternative Purple Practices: Eight Five-Minute Receptivity Meditations",
       "content_type": "chapter",
       "release_day": 6,
       "media": [],

--- a/markdown/02-purple/00-table-of-contents.md
+++ b/markdown/02-purple/00-table-of-contents.md
@@ -12,7 +12,7 @@
 
 [The Practice of Purple: A Daily Tarot Draw](#the-practice-of-purple-a-daily-tarot-draw)
 
-[Alternative Practice Examples: I-Ching, Traffic Lights, Bibliomancy, Synchronicity](#alternative-practice-examples-i-ching-traffic-lights-bibliomancy-synchronicity)
+[Alternative Purple Practices: Eight Five-Minute Receptivity Meditations](#alternative-purple-practices-eight-five-minute-receptivity-meditations)
 
 [The Default Habit of Purple: Vitamins, Probiotics, and Water](#the-default-habit-of-purple-vitamins-probiotics-and-water)
 

--- a/markdown/02-purple/07-alternative-practice-examples-i-ching-traffic-lights-bibliom.md
+++ b/markdown/02-purple/07-alternative-practice-examples-i-ching-traffic-lights-bibliom.md
@@ -4,212 +4,93 @@ stage: 2
 chapter: 7
 order: 7
 slug: alternative-practice-examples-i-ching-traffic-lights-bibliom
-title: "Alternative Practice Examples: I-Ching, Traffic Lights, Bibliomancy, Synchronicity"
+title: "Alternative Purple Practices: Eight Five-Minute Receptivity Meditations"
 content_type: chapter
 release_day: 6
 media: []
 ---
 
-## Alternative Practice Examples: I-Ching, Traffic Lights, Bibliomancy, Synchronicity
+## Alternative Purple Practices: Eight Five-Minute Receptivity Meditations
 
-While the Daily Tarot Draw is the recommended Practice for Purple, APTITUDE is not dogma—it’s a compass, not a commandment. If Tarot doesn’t vibe with you, or if you feel called to experiment with other forms of symbolic receptivity, you’re absolutely encouraged to do so. This is your path. The practice is not sacred. The attunement is.
+While the Daily Tarot Draw is the recommended Practice for Purple, APTITUDE is not dogma—it’s a compass, not a commandment. If Tarot doesn’t resonate, or if you feel called to experiment with other symbolic doorways, you’re absolutely encouraged to do so. This is your path. The practice is not sacred. The attunement is.
 
-The purpose of Purple Practice is to strengthen the muscle of Receptivity—to cultivate your ability to notice, feel into, and relate with the symbols that the universe (or your unconscious, or the morphic field, or the dreamer behind the dream) is already whispering to you. Any practice that sharpens this kind of subtle attention is fair game.
+But before we tour the alternatives, let’s be precise about what a Purple Practice *is*—because it’s easy to get this one wrong, and I got it wrong for years.
 
-In this section, we’ll look at a few alternative forms of divination and symbolic meditation that can serve as excellent complements or replacements to the Major Arcana sequence. These include the ancient Chinese oracle of the I Ching, the surreal and spontaneous symbolism of Traffic Lights, the literary randomness of Bibliomancy, and the art of tuning into Synchronicity itself as a form of ongoing practice.
+These are not divination techniques.
 
-None of these are “better” or “worse” than the others. You might stick with one, rotate them, or invent your own. What matters is the mode: open, symbolic, curious, emotionally attuned, and willing to be surprised.
+I know. Some of them—the I Ching, bibliomancy—have been used as oracles for millennia. You can absolutely use them to ask questions and harvest answers, and there’s a place for that conversation later in this Stage. But that is not what we’re doing here. A Purple Practice is a **five-minute meditation**. The symbol is not a fortune to decode; it is an object of receptive attention—the way the breath is an object of attention in breath meditation. You are not asking the universe for instructions. You are practicing the posture of being *open to* the universe at all.
 
-This is the work of the Archetype Embodier: not just doing, but noticing what’s already being offered. The myth is already speaking. This is how we learn to listen.
+Here’s the frame. In Beige, you built the keystone habit: one to three minutes of grounding, every day, no excuses and no heroics. In Red, you’ll sit for ten. Purple is the bridge—**five minutes** of staying with a symbol while your feeling-body responds to it. Five minutes of Radical Acceptance: receiving whatever arises—boredom, chills, grocery lists, grief—without fixing, chasing, or grading it.
 
-### Brief I-Ching Instructions
+And what you’re listening *for* is specific. Purple corresponds to the sacral center—the seat of feeling, desire, and that visceral, wordless yes-or-no we’ve been calling sacral authority. This is not the “deep intuition” of Teal, where the True Self speaks in gnosis and epiphany. That comes much later, and it comes more easily to those who built this foundation first. Sacral intuition is humbler and closer to the skin: a warmth, a clench, a leaning-toward, a pulling-back. The whole purpose of these five minutes is to give that quiet animal voice your undivided attention once a day, until you can hear it in the wild.
 
-The I Ching, or Book of Changes, is one of the oldest and most refined tools of symbolic receptivity in the world. At its core, it’s a way of dialoguing with the Tao—the flowing pattern of reality—by consulting a system of 64 hexagrams that represent archetypal states, movements, and transitions. In the context of the Purple Stage, we approach the I Ching not as a manual for control, but as an oracle of alignment.
+Every practice below follows the same five-minute arc—a miniature of the Wavelength you’re learning to Inhabit:
 
-You don’t use the I Ching to decide what to do.
+- **Rising (Inspiration):** Arrive. Meet the symbol softly, without reaching.
+- **Peaking (Joy):** Let feeling bloom in response to it—delight, unease, wonder, whatever is true.
+- **Withdrawal (Introspectivity):** When the mind wanders, notice where it went. That drift is information.
+- **Diminishing (Tranquility):** Settle. Let the symbol and the feeling sit together without commentary.
+- **Bottoming Out (Convalescence):** Let it all go quiet. Empty hands, open palms.
+- **Restoration (Recuperation):** Return. One breath of gratitude. Done.
 
-You use it to tune in. To become receptive to the energies at play in and around you. To feel the wave you’re already riding.
+Five minutes. One symbol. No verdicts. Pick whichever of the eight forms below makes your sacral center perk up—that response is itself your first practice.
 
-Here’s how to begin, Purple-style:
+### I Ching: Receiving a Hexagram
 
-1. Frame your question with openness
+The I Ching, or Book of Changes, is one of the oldest symbolic systems on Earth—64 hexagrams mapping the archetypal weather of the Tao. The classical use is oracular. Ours is meditative.
 
-This is not the place for binary yes/no queries.
-Instead, ask: “What do I need to know about this situation?” or “What energy is moving through this decision?” or “How might I come into harmony with what’s unfolding?” Let your question be alive. Let it breathe.
+Toss three coins six times and build your hexagram from the bottom up (an app is fine; APTITUDE is not about ritual perfectionism). But—and this is the move—**don’t ask a question first.** You are not consulting. You are drawing today’s symbol, exactly as you would draw a Tarot card.
 
-2. Cast the hexagram
+Then sit with it for five minutes. Gaze at the figure itself: six lines, broken and unbroken, a little glyph of process. Read the hexagram’s name and image—just the image, not the divinatory commentary—and let it land in the body. *Thunder beneath the mountain.* *The well.* *Pushing upward.* What does your feeling-body do with that? Where does it register? Follow the arc: arrive, feel, drift, settle, empty, return. If you like, read the traditional commentary *after* the timer ends, the same way you look up a card’s meaning after the Tarot practice—curiosity, not confirmation.
 
-The traditional method uses yarrow stalks, but the more common modern version uses three coins. Flip them six times, each time recording a line:
+### Traffic Lights: Receiving Color
 
-- Each toss yields either a solid line (yang) or a
-  broken line (yin).
+This one comes from Damien Echols’ *Ritual*, and in its original form it’s an oracle: ask a question, receive a flash of red, yellow, or green. We’re going to strip the question out and keep the skill—because underneath the yes/no machinery is something precious: the capacity to receive a spontaneous image from the deep psyche on purpose.
 
-- You’ll build the hexagram from the bottom up, one
-  line per toss.
+Sit. Close your eyes. Soften your body the way you would before sleep. Then simply invite a color to arise in the mind’s eye—any color, no agenda—and wait without hunting. This is harder and more interesting than it sounds. The ego wants to *manufacture* a color. Receptivity means letting one *arrive*, the way hypnagogic images arrive at the edge of sleep.
 
-- Some lines are changing lines, which means they
-  carry special attention and create a second, evolving hexagram. Many apps and websites will calculate all of this for you.
+When a color comes, receive it. Don’t interpret it. Notice its texture, its movement, the feeling-tone it carries in your belly. If nothing comes, perfect—spend the five minutes resting in the open, expectant dark. That, too, is the muscle. Empty-handed receptivity is still receptivity; in some ways it’s the purest rep.
 
+### Bibliomancy: Receiving a Passage
 
-If you prefer, there are also beautifully designed apps or physical decks that present the I Ching visually, without the coin method. That’s completely valid here. APTITUDE is not about ritual perfectionism—it’s about resonance.
+Choose a book with gravity—the Tao Te Ching, a poetry collection, a novel that has marked you. Take one full breath. With eyes closed, open the book and let your finger land.
 
-3. Receive the image
+Read only that passage. Resist the urge to keep flipping for a “better” one; that urge is the grasping this practice exists to soften. Then put the book down and spend the remaining minutes with what you received. Not analyzing—*tasting*. What image glows? What word snags? What does your sacral center do as you hold the line in mind—lean in, or pull back? Let the passage be weather moving through you, not a riddle assigned to you.
 
-Look up your hexagram. Read it slowly. Then pause.
-Sit with it. You are not looking for an instruction—you are feeling for a reflection. What mood does it carry? What archetype is being evoked?
-What emotion, story, or myth might this hexagram point toward in your life?
+### Synchronicity Tracking: Receiving the Day
 
-4. Let the meaning shimmer
+Synchronicity is the wildest form of Purple attention—symbols arising not from cards or coins but from the field of your actual life. The repeating number. The stranger who uses your secret word. The song that answers the thought.
 
-If a particular line or phrase jumps out, follow it.
-If it confuses you, perfect. Let that confusion work on you the way a koan does. The I Ching is not a text to master. It’s a mirror. Let it show you something you didn’t expect to see.
+As a five-minute sit: settle, close your eyes, and replay the last twenty-four hours slowly, like dream footage. You’re not auditing your productivity. You’re scanning for *glimmers*—moments that felt charged, timed, mythic, or strangely addressed to you. When one surfaces, hold it the way you’d hold a card: feel it, don’t solve it. Afterward, log it in a sentence or two—a running Synchronicity Log sharpens this ear remarkably fast. Over weeks, you’ll find you notice the glimmers *as they happen*, which is the entire point: a life received symbolically, in real time.
 
-5. Optional: Journal your impressions
+### Candle Gazing (Trataka): Receiving Imagery
 
-You might want to note what the hexagram felt like to you before reading the commentary—and then again afterward. Was there a shift? Did it affirm something? Challenge something? Invite something?
-Use the Purple journaling prompts as a container if you’d like.
+Light a candle. Set it at eye level, an arm’s length away. Rest your gaze on the flame—soft eyes, slow blinks—for the first couple of minutes. Then close your eyes and watch the afterimage bloom and drift in the dark.
 
-Above all: let this be a ritual of Receptivity. You are not summoning a being or demanding a sign. You are attuning to the underlying vibration of your life as it moves in the moment. Sometimes what you find will feel deeply personal. Other times it may feel alien or abstract. Either way, it’s part of the language of the Tao. Part of the myth you live inside.
+Here’s the Purple twist: as the afterimage fades, stay at that inner screen and *invite imagery*—faces, landscapes, shapes, colors—without demanding any. Whatever arises, receive it with the same hospitality you’d offer a guest: attention without interrogation. Trataka is ancient, and its gift here is exquisite calibration of the receiving channel itself: first an outer light, then its echo, then whatever the deep mind paints with the remnant glow. Three layers of subtlety, one unbroken posture of welcome.
 
-Let it speak. Let yourself receive.
+### Dream Recollection and Symbol Mapping: Receiving the Night
 
-### How to Employ the Traffic Lights Method
+Do this one in the morning, before the day colonizes your mind. Sit comfortably, eyes closed, and let last night’s dream re-approach you. Don’t chase the plot. Dreams retreat from pursuit; they return to stillness. Hold whatever fragment remains—a corridor, a color, an animal, a feeling of being late—and let it sit in the center of attention for the full five minutes.
 
-The Traffic Lights Method, as explained by Damien Echols in Ritual, is a beautifully simple way of opening yourself to symbolic guidance. Unlike the Tarot or the I Ching, this isn’t about meditating on pre-existing imagery—it’s about becoming receptive to the spontaneous appearance of color as a message from the deeper or higher parts of your psyche: your guides, your Holy Guardian Angel, your Future Self, your Internal Pantheon of Archetypes—whatever metaphor you use for the wise and loving intelligence behind your intuition.
+Afterward, map it: one line in your journal naming the symbol, one line naming the feeling it carried. No dream dictionaries. Your psyche has its own vocabulary, and this practice is how you learn it—one received fragment at a time. If no dream survived the waking, sit with the *texture* of the night instead. Even fog is a symbol.
 
-It works like this:
+### Archetypal Mantra: Receiving Resonance
 
-1. Ask your question
+Choose a word or name dense with archetypal charge—*Hekate*, *Lakshmi*, *Sophia*, *Stillness*, or a phrase like *I am held*. For five minutes, repeat it slowly—aloud, whispered, or silently—and here is the receptive turn: put your attention not on the *saying* but on the *echo*. The feeling that ripples in the body after each repetition. The images the name stirs. The way the word changes flavor by the twentieth pass.
 
-This can be internal or spoken aloud. The form matters less than the sincerity. You might ask: “Should I go to this event?” “Is this person good for me?” “Is now the time to act?” Or even just: “Is this aligned with my path?”
+You are not invoking a being or commanding a result. You are striking the same bell again and again and listening to what resonates in your particular instrument. When the mind drifts (it will), notice where it went—the drift was probably set in motion by the resonance—and return to the bell.
 
-Keep the question simple. Make it something the deeper parts of you can answer viscerally.
+### Personal Totem: Receiving an Object
 
-2. Open to the Field
+Choose an object that already carries charge for you: a stone from a meaningful place, a grandmother’s ring, a feather, a shell. Hold it, or set it before you.
 
-This is the Receptivity piece. Instead of trying to “figure it out,” you soften. Relax your body. Quiet your mind just enough to listen. You’re not hunting for a sign—you’re inviting one.
-You’re attuning yourself to whatever image, impression, or flash arises.
+Spend five minutes with it as a *presence* rather than a possession. Feel its weight and temperature. Let your eyes wander its surface like terrain. Then let it open: what memories, people, and places live in this object? What does your body feel as they surface? An heirloom can hold an entire lineage; a river stone can hold a whole summer. You’re practicing the animist attention of Purple—the felt sense that matter is storied, and that you can sit quietly and let a thing tell you what it holds.
 
-3. Receive a color
+### Same Muscle, Eight Doorways
 
-The answer comes in the form of a sudden inner visual: a flash of one of the three classic traffic light colors. This flash might be imagined behind closed eyelids, or appear in your mind’s eye, or show up spontaneously on your screen, a passing car, or someone’s outfit—especially if you’ve just asked your question. The universe loves synchronicity.
+None of these is better than the others. Stick with one, rotate weekly, or let your sacral response choose each morning. What matters is the mode: open, symbolic, curious, emotionally attuned, and willing to be surprised—five minutes a day, every day, until receptivity stops being a technique and becomes a way you stand in the world.
 
-- Green: Yes. Proceed. This is aligned.
+That’s the work of this Stage: not doing more, but noticing what’s already being offered. The myth is already speaking.
 
-- Red: No. Not now. Not this.
-
-- Yellow: Caution. Wait. Consider again. There’s
-  more to understand.
-
-
-4. Trust the first impression
-
-The ego loves to second-guess. It wants more data.
-It wants to know why. But the Traffic Lights Method isn’t for the ego—it’s for the part of you that already knows. The color you get first is the one that counts. Don’t dig or try to force a different answer.
-
-5. Let it be guidance, not gospel
-
-This isn’t a commandment. It’s a signal. A pulse. A flash of archetypal intuition. Let it guide your next step, not dictate your entire path. Receptivity, especially at Purple, is about relationship, not submission. You’re not giving your power away—you’re checking in with the larger field that includes you.
-
-Some Adepts use this method only when a decision feels especially foggy. Others make it a daily practice—“What energy wants to guide me today?” Either way, it’s a gentle, fast, and shockingly accurate technique for entering a relationship with Source.
-
-You don’t need a full spread of cards or an hourlong meditation. Sometimes, the soul just needs a light.
-
-Red. Yellow. Green. Go.
-
-### What is Bibliomancy? How do I use it?
-
-Bibliomancy is the art of divining meaning by opening a book at random and letting your eye fall upon a passage that speaks. It’s one of the simplest, most ancient, and most delightfully mystical forms of symbolic receptivity—a spontaneous communion with language, layered with resonance and ripe with surprise. It’s like letting the universe hand you a sentence.
-
-In the context of Purple, bibliomancy is not about fortune-telling or trying to bend fate to your will. It’s about listening. Tuning your awareness to archetypal meaning as it emerges through text. Like Tarot, like the I Ching, like traffic light flashes or dream symbols, bibliomancy is an exercise in opening yourself to messages you didn’t consciously craft.
-
-And, crucially, it fits beautifully into the rhythm of Purple Practice: a gentle 5-minute daily devotion designed to prepare you, over time, for the 45-minute meditation practices that APTITUDE will guide you toward in the later Stages. This is warm-up. A sacred stretch.
-
-Here’s how to do five minutes of bibliomancy:
-
-1. Select your book
-
-Any book with gravity, richness, or symbolic texture will do. Sacred texts like the Tao Te Ching, the Bhagavad Gita, or the Bible are traditional. But a favorite novel, a book of poetry, a mystical text, or even a well-loved essay collection can work. Some Adepts use whatever book is nearest. Others create a small library of personal oracular volumes. There’s no wrong answer.
-
-2. Center yourself
-
-Take one full breath. Maybe three. This isn’t about performance—it’s about opening. Receptivity requires even a moment of pause. Let your body soften. Maybe whisper a little invocation like, “Show me what I need to see.” You’re not commanding—you’re asking.
-
-3. Open and land
-
-With eyes closed, open the book to a random page.
-Let your finger drift to a passage. When it feels right, open your eyes and read only that. Resist the urge to keep flipping or search for a “better” one. Trust the hit.
-
-4. Reflect for a few minutes
-
-Set a five-minute timer. Sit with the words. What images, emotions, or memories do they stir? Does anything in the passage feel charged, uncanny, or eerily relevant? Don’t overthink. Just stay with it.
-
-If your thoughts wander—perfect. That’s the practice. Follow the Wavelength:
-
-- Rising: Gently gaze at the words. Let their energy
-  arrive.
-
-- Peaking: Notice when your attention slips away.
-
-- Withdrawal: Review where your thoughts went.
-
-- Diminishing: Relate that mental drift back to the
-  passage.
-
-- Bottoming Out: Let the whole thing fade into a
-  quiet hush.
-
-- Restoration: Regather yourself. Smile. You
-  listened.
-
-
-Bibliomancy at Purple is not an intellectual exercise—it’s a somatic and symbolic one. You are training your nervous system to receive subtle messages. You are building a habit of presence through wonder.
-
-And remember: five minutes is plenty. Today, it’s a single page. By the time we reach the latter Stages of APTITUDE, you’ll be sitting for 45 minutes, moving through elaborate sequences of concentration and integration. But for now, this? This is sacred enough.
-
-So crack the spine.
-
-Ask a question.
-
-Let the book speak.
-
-### Tracking and Acting on Synchronicities
-
-Synchronicity is perhaps the purest form of Purple divination—not mediated through cards, coins, or books, but arising spontaneously from the field of reality itself. It’s the random lyric that echoes your exact inner conflict. The stranger who uses your secret word. The repeating number, animal, image, or phrase that appears so many times in a row it starts to feel like someone’s trying to get your attention.
-
-This, too, is a practice.
-
-In the context of Purple, tracking and acting on synchronicities is about learning to receive life symbolically. It asks you to treat your experiences not just as events, but as messages—not in a paranoid or solipsistic way, but in the playful, reverent, meaning-rich mode of the Archetype Embodier. The universe is not speaking to you as its center, but it includes you, and it might just be speaking with you—if you’re willing to listen.
-
-So how does this become part of your 5-minute Purple Practice?
-
-Easy. Make the last few minutes of your daily Practice—whether Tarot, Bibliomancy, or otherwise—an opportunity to review the day (or previous 24 hours) for potential synchronicities.
-Ask:
-
-- Did anything stand out today that felt too
-  perfectly timed to be chance?
-
-- Did I notice a theme repeating across different
-  domains (a dream, a meme, a comment, a billboard)?
-
-- Is there a word or image that keeps surfacing?
-
-- Was there an interaction that felt mythic or
-  numinous?
-
-
-Write them down. Just a sentence or two. Even better, keep a “Synchronicity Log” as a running list in your journal or Notes app. Over time, this act of tracking will sharpen your inner ear for archetypal resonance. You’ll start noticing patterns sooner. Feeling into the symbolic fabric more naturally. Becoming more skilled at receiving the myth you’re already inside of.
-
-And if something feels like it’s asking you to act—act. With discernment, of course. But if a card, a phrase, and a dream all point to reconnecting with someone, or creating something, or letting something go… maybe it’s not just coincidence. Maybe it’s rhythm.
-
-This is not about treating the world like a puzzle to be decoded. It’s about learning to walk in it like a dream. Awake, curious, open.
-
-So take five minutes. Gaze. Breathe. Listen.
-
-Then review your day.
-
-What’s glimmering?
-
-What wants your attention?
-
-What might be whispering: Yes?
+This is how we learn to listen.

--- a/markdown/02-purple/README.md
+++ b/markdown/02-purple/README.md
@@ -11,7 +11,7 @@ This folder contains the modular sections for the PURPLE stage of the APTITUDE c
 - [The Relationship to Free Will at Purple: Archetype Embodier](./04-the-relationship-to-free-will-at-purple-archetype-embodier.md)
 - [The Mode of the Wavelength of Purple: Inhabit (Feel)](./05-the-vibe-wavelength-of-purple-internalize-feel.md)
 - [The Practice of Purple: A Daily Tarot Draw](./06-the-practice-of-purple-a-daily-tarot-draw.md)
-- [Alternative Practice Examples: I-Ching, Traffic Lights, Bibliomancy, Synchronicity](./07-alternative-practice-examples-i-ching-traffic-lights-bibliom.md)
+- [Alternative Purple Practices: Eight Five-Minute Receptivity Meditations](./07-alternative-practice-examples-i-ching-traffic-lights-bibliom.md)
 - [The Default Habit of Purple: Vitamins, Probiotics, and Water](./08-the-default-habit-of-purple-vitamins-probiotics-and-water.md)
 - [Yes-And-Ness: A balance between Radical Agency and Radical Acceptance](./09-yes-and-ness-a-balance-between-radical-agency-and-radical-ac.md)
 - [Archetypal Gender: Masculine, Feminine, and Baphomet](./10-archetypal-gender-masculine-feminine-and-baphomet.md)


### PR DESCRIPTION
Closes #14

## What changed

`02-purple/07` is regenerated from scratch per the issue's deliverables:

- **The reframe**: every practice is now a **5-minute meditation promoting receptivity to sacral intuition**, explicitly *not* a method of answering questions. The intro names the distinction directly (and distinguishes sacral intuition from Teal's True-Self intuition, per the issue).
- **The bridge**: positioned as the intermediary between Beige's 1–3 minutes and Red's 10 — five minutes of radical acceptance, daily.
- **Structure**: a shared five-minute arc maps to Purple's Inhabit (Feel) Rx terms from the CSV (Inspiration → Joy → Introspectivity → Tranquility → Convalescence → Recuperation), so the practice embodies the Mode it belongs to.
- **Same options kept**: I Ching (draw a hexagram like a card — no question asked), Traffic Lights (rebuilt from yes/no oracle into a color-receptivity drill, Echols still credited), Bibliomancy, Synchronicity tracking.
- **Added from `APTITUDE - Alternative Practices.csv`** (purple column, read top-down): Candle Gazing (Trataka) with invited imagery, Dream Recollection & Symbol Mapping, Archetypal Mantra (e.g. Hekate, Lakshmi), Personal Totem meditation — all at the same 5-minute duration.
- Frontmatter `title` updated to "Alternative Purple Practices: Eight Five-Minute Receptivity Meditations"; slug/filename untouched (id stable); purple TOC/README link text updated; manifest regenerated.

~1,800 words, voice matched to the surrounding Purple chapters (sacral authority, Yes-And-Ness, anti-dogma framing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)