### PR TITLE
Purple voice fixes: tighter intro, de-AI'd journaling prose (#9, #10)

### DIFF
--- a/markdown/02-purple/01-what-is-purple.md
+++ b/markdown/02-purple/01-what-is-purple.md
@@ -12,30 +12,24 @@ media: []
 
 ## What is Purple?
 
-Purple is the second Stage of APTITUDE, and the second half of the first polarity: Yes-And-Ness. While Beige is concerned with Agency—the “And” that gives us the will to act, to move, to survive—Purple brings its sacred complement: Receptivity. It is the “Yes.”
+Purple is the second Stage of APTITUDE, and the second half of the first polarity: Yes-And-Ness. Beige was concerned with Agency—the “And” that gives us the will to act, to move, to survive. Purple brings its complement: Receptivity. The “Yes.”
 
-If Beige is the firestarter, Purple is the flame that dances on its own. Where Beige teaches us how to hunt, build, and protect, Purple reminds us that not everything worth having must be earned. Some things must be received.
+If Beige is the firestarter, Purple is the flame that dances on its own. Beige taught you how to hunt, build, and protect. Purple makes a stranger claim: not everything worth having must be earned. Some things can only be received.
 
-This is a fundamental shift. It’s not about passivity, but openness. In the cosmology of APTITUDE, this is the transition from the Root’s compulsion to do into the Sacral’s invitation to feel. From the stoic pursuit of control to the sensual art of attunement. We move from surviving the world to synchronizing with it.
+In the cosmology of APTITUDE, this is the move from the Root Chakra to the Sacral—from the compulsion to do into the invitation to feel.
 
 The Spiral Dynamics model describes Purple as the "Magical" Stage—a time when early humans and early children alike engage with reality as if it were alive, communicative, and responsive to intention. In modern developmental terms, this is often dismissed as primitive or childlike. But in APTITUDE, Purple is not something you leave behind as you "mature"—it's a capacity you refine and integrate. You never outgrow the need for myth, symbol, and attunement. These remain essential throughout life.
 
-Because Purple doesn’t just represent naïve animism—it represents the capacity to listen. To attune to the patterns behind the veil of the sensory world. To interpret the symbolic. To sense what’s emerging in the field around you. To know, deep in your gut, what the moment requires.
-
-This attunement is not a hallucination—it’s an embodied skill. A practice of receptivity to Source, to Self, and to Story.
+Because Purple doesn’t just represent naïve animism. It’s the capacity to listen: to take a symbol seriously and a hint personally, and to know in your gut what a moment requires before your mind has finished arguing about it. That gut-knowing isn’t a hallucination. It’s an embodied skill, and like any skill, it sharpens with practice.
 
 One way to understand this is through the principle of sacral authority, a Human Design concept that dovetails elegantly with the Purple frequency. In this framework, the sacral center (just below the navel) responds with a visceral yes or no to the possibilities life offers. This instinctual knowing doesn’t argue, explain, or rationalize. It responds. When we are attuned to it—when we are receptive—we begin to sense which invitations from life carry real power and alignment.
 
-Receptivity is not merely openness to pleasure, although pleasure is certainly a part of it. It is openness to meaning.
-To archetypes. To emotions. To the shamanic voice of myth as it echoes through synchronicity and symbol. It is the capacity to let ethics arise in the body, not just in the mind. It is what allows us to receive insight as gnosis, rather than merely as data.
+Receptivity includes openness to pleasure—we’ll get there—but it goes further: openness to meaning. It’s what lets ethics arise in the body instead of only in the mind, and what allows insight to arrive as gnosis rather than as data.
 
-This is the real invitation of Purple: to shift from effort to trust. From extraction to cooperation. From striving to resonance. The idea that we must always do in order to become whole is a symptom of a culture stuck in Beige. Purple introduces the counterpoint:
-sometimes, we become whole by receiving what has already been given. The stories, the symbols, the sensations—they are not scarce. They are already in the field, waiting for us to say “yes.”
+The idea that we must always *do* in order to become whole is the symptom of a culture stuck in Beige. Purple is the counterpoint: sometimes we become whole by receiving what has already been given. The myth we live inside is not only authored by us. It is also offered to us.
 
-The myth we live inside is not only authored by us.
-It is offered to us. And when we balance the active with the receptive, when we integrate Purple alongside Beige, we begin to dance with the universe instead of wrestling it to the ground.
+So for the next 21 days, you’ll practice saying Yes to life—not a blind or uncritical Yes, but a discerning, felt, open-hearted one. Through a daily symbolic draw, through tracking dreams and synchronicities, and through the journaling prompts ahead, you’ll train the unglamorous art of noticing what your life is already trying to hand you.
 
-In this Stage, you’ll begin to cultivate that dance.
-Through divination, myth, embodiment, and intuition, you will practice saying Yes to life—not a blind or uncritical yes, but a discerning, felt, open-hearted one. You’ll begin to notice the ways in which your life is already responding to your presence, if only you become present enough to perceive it.
+None of this requires belief. It requires attention. The world has been sliding symbols under your door for as long as you’ve been alive. Purple is the three weeks where you finally bend down and pick them up.
 
-Purple is the garden. The fruit is already ripe. This is the part where you learn how to notice it. And choose to receive.
+Beige taught you to keep your promises to yourself. Purple teaches you to let life keep a few of its promises to you.

--- a/markdown/02-purple/03-the-journaling-prompts-of-purple.md
+++ b/markdown/02-purple/03-the-journaling-prompts-of-purple.md
@@ -12,7 +12,7 @@ media: []
 
 ## The Journaling Prompts of Purple
 
-To further embody the energy of Purple and the Mood of Receptivity, this Stage invites you into journaling practices designed not to assert or control, but to listen. To feel into your life. To receive its messages. These prompts are not meant to extract insight through force of will, but to open a channel for it. Your role here is not to “figure it out,” but to soften enough that something true might rise up on its own.
+To further embody the energy of Purple and the Mood of Receptivity, this Stage’s journaling works a little differently than you may be used to. You aren’t using the page to plan, vent, or solve. You’re using it to listen. If you can soften your grip on the pen—and on the need to figure anything out—something true tends to rise on its own. These prompts exist to give it somewhere to land.
 
 Some basic guidelines, borrowed from Beige and still in full effect:
 
@@ -26,7 +26,7 @@ Do not cross anything out.
 
 If you stall, simply write that down and keep going until you move through the block.
 
-This is less about “journaling” in the self-help sense and more about cultivating a receptive attention. Think of it as divinatory writing. You’re not wrangling your thoughts into order—you’re inviting the subtle, the symbolic, the archetypal, and the magical to speak through your hand.
+This is less “journaling” in the self-help sense and more divinatory writing: keep the hand moving, and let whatever is subtle, symbolic, or strange in you have a turn with the pen.
 
 Here are your Purple prompts:
 
@@ -36,22 +36,18 @@ Don’t try to define these terms intellectually—feel into them. Explore your 
 
 “What am I grateful for?”
 
-You have two beautiful paths here. One is to make a list—short sentences, as many as you can. The other is to pick just three things and go deep. Exhaustively deep. Write everything you love about that person, place, memory, or thing. Describe its texture, scent, sound, meaning. Either way, the crucial move comes at the end: pause.
-Notice. Tune in receptively to the somatic address of your gratitude.
-Where does the feeling live in your body? What color is it? What shape?
-Can you stay with it for a breath or two? Let it bloom.
+You have two beautiful paths here. One is to make a list—short sentences, as many as you can. The other is to pick just three things and go deep. Exhaustively deep. Write everything you love about that person, place, memory, or thing. Describe its texture, scent, sound, meaning. Either way, the crucial move comes at the end: pause and notice where the gratitude lives in your body. Stay with that sensation for a breath or two before you close the notebook. The list was the warm-up; this is the practice.
 
 “What synchronicities have whispered to me lately, and what might they be trying to say?”
 
-This is your mythic mirror. Write down every moment that felt like a wink from the universe. The more mundane, the better.
-The song that came on at the right time. The phrase someone echoed back to you unprompted. The recurring symbol. You don’t have to believe they’re “real.” Just explore the feeling they bring. What stories do they suggest? What invitations? What alignments?
+Write down every moment that felt like a wink from the universe—the more mundane, the better. The song that came on at the right time. The phrase someone echoed back to you unprompted. The symbol that keeps recurring. You don’t have to believe they’re “real.” Just explore the feeling they bring, and what they might be inviting you toward.
 
 “How does my sacral center say Yes? How does it say No?”
 
-This is the beginning of building trust with your intuitive body. Recollect moments when you felt clearly aligned or misaligned with something or someone. Where did you feel it? What was the sensation? A warmth? A drop? A tightening? A pulsing? This is less about metaphor and more about mapping: you are charting the geography of your inner knowing.
+This is the beginning of building trust with your intuitive body. Recollect moments when you felt clearly aligned or misaligned with something or someone. Where did you feel it, and what was the sensation—a warmth, a drop, a tightening, a pulse? You’re building a reference map here: the specific signals your body uses for yes and for no, recorded while they’re fresh, so you can read them in real time later.
 
 “What challenges and achievements have shown up for me during this APTITUDE stage?”
 
 This is your personal progress report, but not in a gold-star sense. Think of it more like a shaman’s travelogue. What has tested your receptivity? What has opened you? What have you had to let go of to make room for something better? What little victories have bloomed quietly in the background?
 
-Receptivity is a mood, but also a muscle. This journaling practice strengthens it—not by exertion, but by practice in allowing. Let these prompts unfold you. Let the pen become your antenna. The page, your altar. The act of writing, a soft Yes.
+Receptivity gets stronger the way anything does: through repetition. Twenty to thirty minutes, once a week, pen moving, ears open. Don’t try to write anything good. Stay soft, keep listening, and let the page do the rest.


### PR DESCRIPTION
Closes #9
Closes #10

## What is Purple? (#9 — repetitive, ending doesn't land)

- The same doing→receiving idea was restated **five times** ("not passivity but openness", "effort to trust", "extraction to cooperation", "striving to resonance", "dance instead of wrestling"). It now gets said once, well, and the chapter moves on.
- Cut the AI-accent constructions the rest of the issue set flags: fragment crescendos ("To attune… To interpret… To sense… To know"), triple alliteration ("Source, Self, and Story", "surviving/synchronizing").
- Kept what works: the firestarter/flame image, the Spiral Dynamics "Magical stage" passage, the sacral-authority paragraph.
- **New ending** that lands instead of the garden/fruit fade-out:

  > The world has been sliding symbols under your door for as long as you've been alive. Purple is the three weeks where you finally bend down and pick them up.
  >
  > Beige taught you to keep your promises to yourself. Purple teaches you to let life keep a few of its promises to you.

## Journaling prompts (#10 — AI accent)

Rewrote the flagged closer (antenna/altar/soft-Yes metaphor stack) and every other passage with the same patterns — stacked "not X but Y" constructions (three in a row in the old intro), question crescendos, and the "mythic mirror"/"geography of inner knowing" word-sound games. **All five prompts are kept verbatim**; only the connective prose changed. The guidelines list is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)