### PR TITLE
Add the Return Journey: five weeks of Metta (#7)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -722,6 +722,18 @@
       "path": "markdown/04-blue/14-practicing-love-off-the-cushion.md"
     },
     {
+      "id": "blue-15",
+      "stage": 4,
+      "chapter": 15,
+      "order": 15,
+      "slug": "the-return-journey-five-weeks-of-metta",
+      "title": "The Return Journey: Five Weeks of Metta for When Life Becomes Unmanageable",
+      "content_type": "chapter",
+      "release_day": 14,
+      "media": [],
+      "path": "markdown/04-blue/15-the-return-journey-five-weeks-of-metta.md"
+    },
+    {
       "id": "orange-1",
       "stage": 5,
       "chapter": 1,

--- a/markdown/04-blue/15-the-return-journey-five-weeks-of-metta.md
+++ b/markdown/04-blue/15-the-return-journey-five-weeks-of-metta.md
@@ -1,0 +1,57 @@
+---
+id: blue-15
+stage: 4
+chapter: 15
+order: 15
+slug: the-return-journey-five-weeks-of-metta
+title: "The Return Journey: Five Weeks of Metta for When Life Becomes Unmanageable"
+content_type: chapter
+release_day: 14
+media: []
+---
+
+## The Return Journey: Five Weeks of Metta for When Life Becomes Unmanageable
+
+Before you leave Blue, I want to hand you something you’ll use for the rest of the course—and, if it serves you the way it has served me, for the rest of your life.
+
+Back in Beige, when we mapped the Withdrawal phase of the Wavelength, the advice was essentially defensive: circle the wagons. Drop into Low Grit mode. Jettison the overcommitments, protect the keystone habit, and ride out the valley. Call that what it is—a tactical retreat. It’s the right move when energy contracts, and it will keep being the right move for ordinary lows.
+
+But some lows are not ordinary.
+
+Sometimes life becomes genuinely unmanageable. The job collapses, or the relationship does. Grief moves in. Shame gets the microphone and starts narrating everything you do, or rage starts leaking into rooms it doesn’t belong in. In that weather, a tactical retreat isn’t enough—because the problem is no longer your energy budget. The problem is that your relationship with yourself has gone hostile, and no amount of habit triage repairs that.
+
+Until now, retreating was all you had. But Blue just taught you Metta. Which means you now qualify for the stronger medicine.
+
+I call it the Return Journey: five weeks of loving-kindness, one circle of care per week, walked in order. It’s the same 15-minute practice you learned in this Stage—same phrases, same structure—but stretched across five weeks and aimed, deliberately, at putting you back into relationship with the world after something has knocked you out of it.
+
+### When to begin one
+
+You begin a Return Journey when you notice that you are overwhelmed—not “busy week” overwhelmed, but the deeper kind:
+
+- Shame or rage has been driving for days, and the Practices that normally restore you are bouncing off.
+- You’ve done the tactical retreat—dropped to Low Grit, protected the keystone—and you’re still sinking.
+- The inner monologue has turned prosecutorial. You’ve become someone you flinch from.
+
+Any of those is the bell. You don’t need to earn it, justify it, or wait until things get worse. Pausing your current Stage’s Practice to walk a Return Journey is not falling behind—it is the curriculum. The Wavelength was never going to spare you the troughs; APTITUDE’s promise is that you’ll stop drowning in them.
+
+(And to be clear about sequencing: this tool unlocks *after* Blue, because it requires the Metta skill you’ve just spent three weeks building. If you’re reading ahead, or if the bottom falls out during Orange, Green, Yellow—any Stage from here to the end—this is the move. Come back to this chapter. It will keep.)
+
+### The five weeks
+
+One week per circle, fifteen minutes a day, in this order:
+
+**Week One: Yourself.** Every phrase, all week, aimed at you. *May I be safe. May I be happy. May I be healthy. May I live with ease.* If shame is the storm that triggered this Journey, expect this week to be the hardest—saying these phrases to yourself while shame argues back is the actual work. Don’t fight for the feeling. Just keep offering the words, the way you’d keep leaving food out for a frightened animal.
+
+**Week Two: Someone easy to love.** A child, a dear friend, a pet, a grandparent—someone your heart opens toward without effort. After a week of grinding against self-directed resistance, this week usually feels like the thaw. Let it. The warmth you generate here is not a detour; it’s the proof that the channel still works.
+
+**Week Three: An acquaintance.** The barista, the neighbor, the coworker you’ve never really considered. Someone neutral. This is where Metta stops being sentiment and becomes capacity—love with no story attached, offered to someone who has never earned or forfeited it. Most people find this week strangely peaceful. The nervous system learns: care doesn’t require a reason.
+
+**Week Four: An “enemy.”** Someone difficult. Someone who hurt you, or someone you envy, resent, or can’t stop arguing with in the shower. Note the quotation marks—the practice doesn’t require you to declare anyone evil, only to pick the person your chest tightens around. Start gently; if the full phrases won’t come, use *May you be free from the suffering that makes you act this way.* This is the week that breaks the rage loop, because rage needs a frozen image of its target, and Metta melts the frame.
+
+**Week Five: The whole world.** All beings, everywhere, without exception—which, note, includes both you and the “enemy,” now held in the same field. *May all beings be safe. May all beings be happy.* This is the week the Journey earns its name: you started collapsed around a wound, and you end facing the world again, on speaking terms with all of it.
+
+### Why it works
+
+The Return Journey is the Wavelength applied to the heart. The five circles trace the same arc as any Restoration: begin at the wound (you), warm the system (easy love), expand the range (neutral), metabolize the poison (enemy), and rejoin the whole (world). Shame isolates; the Journey systematically de-isolates. Rage fixates; the Journey systematically widens. You cannot complete five honest weeks of this and remain in the same relationship to what knocked you down.
+
+Afterward, return to whatever Stage you paused. You haven’t lost five weeks. You’ve practiced the single most important move an Adept ever learns: how to come back.

--- a/markdown/04-blue/README.md
+++ b/markdown/04-blue/README.md
@@ -19,6 +19,7 @@ This folder contains the modular sections for the BLUE stage of the APTITUDE cou
 - [Blue's Shadow: The Drama Triangle (Victim, Villain, Savior)](./12-blues-shadow-the-drama-triangle-victim-villain-savior.md)
 - ["EXPRESS (Feel)"—Full 6-Phase Wavelength Breakdown](./13-express-feelfull-6-phase-wavelength-breakdown.md)
 - [Practicing Love Off the Cushion](./14-practicing-love-off-the-cushion.md)
+- [The Return Journey: Five Weeks of Metta for When Life Becomes Unmanageable](./15-the-return-journey-five-weeks-of-metta.md)
 
 ## Navigation
 
@@ -30,4 +31,4 @@ This folder contains the modular sections for the BLUE stage of the APTITUDE cou
 
 Original monolithic file: `../4.BLUE.md` (preserved as backup)
 
-Total sections: 15
+Total sections: 16


### PR DESCRIPTION
Closes #7

## What this adds

A new Blue chapter — `04-blue/15-the-return-journey-five-weeks-of-metta.md` (~900 words) — introducing the five-week Metta protocol the issue describes, answering its three questions directly:

- **When do you do it?** When overwhelmed in the deep sense: shame or rage interrupting growth, life genuinely unmanageable, and the *tactical retreat* (Beige's circle-the-wagons / Low Grit Withdrawal response — now named as such, creating the contrast the issue asks for) has already failed.
- **Who is the Metta for?** One week each, in order: yourself → someone easy to love → an acquaintance → an "enemy" (quotation marks honored — the person your chest tightens around, not a declared villain) → the whole world, which by week five includes both you and the enemy in the same field.
- **At what stage?** After Blue — it requires the 15-minute Metta skill Blue just built, and the chapter explicitly tells readers in any later Stage to come back to it and pause their current Practice without "falling behind."

Placement rationale: end of Blue, right after "Practicing Love Off the Cushion," so it lands as the Stage's parting gift; it reuses the exact 15-minute structure from `06-the-practice-of-blue-metta-meditation.md`. Framed through the course's own machinery (the five circles as a Restoration arc of the Wavelength; shame isolates / the Journey de-isolates).

Identity/pipeline: `blue-15` id, `release_day: 14` (daily default), Blue README updated, manifest regenerated — back to **209 chapters**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)