### PR TITLE
Purple free-will → 'The Hedonist' (#11) — calibration draft for review

### DIFF
--- a/markdown/02-purple/04-the-relationship-to-free-will-at-purple-archetype-embodier.md
+++ b/markdown/02-purple/04-the-relationship-to-free-will-at-purple-archetype-embodier.md
@@ -1,53 +1,29 @@
----
-id: purple-4
-stage: 2
-chapter: 4
-order: 4
-slug: the-relationship-to-free-will-at-purple-archetype-embodier
-title: "The Relationship to Free Will at Purple: Archetype Embodier"
-content_type: chapter
-release_day: 3
-media: []
----
+## The Relationship to Free Will at Purple: The Hedonist
 
-## The Relationship to Free Will at Purple: Archetype Embodier
+Let's get right to it. What is the relationship to Free Will at Purple?
 
-Let’s get right to it. What is the relationship to Free Will at Purple?
+At Beige you were a Biological Machine—reflexes and instinct doing whatever it took to survive. At Purple, the machine wakes up and discovers it can *want*.
 
-That’s what this whole course is about, after all—and in Purple, the answer begins to shimmer, refract, and take on mythic shapes.
+The senses come online. Color, taste, warmth, music, the particular ache of wanting someone across a room. A whole world of pleasure announces itself, and your fledgling free will gets aimed at a single question: how do I get more of that?
 
-While Beige expressed Free Will as the awakening of Agency—the raw capacity to do things that matter—Purple introduces a subtler, stranger mode of volition. One that emerges not from willpower, but from alignment. In this Stage, Free Will is not the conscious architect of action, but the medium through which archetypes express themselves. You are the vessel, not the sculptor.
+This is Purple's first-pass energy. Its overdose. Its shadow. We call it the Hedonist.
 
-We call this relationship to Free Will: The Archetype Embodier.
+The Hedonist is obsessed with slaking worldly desire. Not savoring it—*slaking* it. Pouring water on a fire that was never going to go out.
 
-This idea might feel a bit slippery at first, especially if you’re still shaking off the materialist hypnosis that insists we are fully autonomous, rational actors. But step into the mythic lens and it becomes clear: personality is not a sovereign, isolated construction. It is a collage. A tapestry. A haunted patchwork of echoes, symbols, and role models.
+Purple is the Sacral chakra: the seat of pleasure, appetite, and longing. None of that is the enemy. The body is supposed to want. The trap is the loop.
 
-Most of your behavior, when examined honestly, is the byproduct of repeated patterns—habits—that were shaped by influence.
-These influences are not merely environmental or social. They are archetypal.
+Because craving has a cruel design: it cannot be satisfied by getting what it craves. The Buddha named this twenty-five centuries ago—taṇhā, thirst, the root of our suffering. You drink. For a breath the thirst is gone. Then it returns, thirstier.
 
-You did not invent yourself. You received yourself.
+I have done long tours as a card-carrying Hedonist. The snack after the snack. The scroll that eats the evening. The relationship I stayed in because leaving meant feeling something I didn't want to feel. Each one promised it would finally be enough. None of them were.
 
-Look close: your laugh is your mother’s with a twist. Your favorite outfit is a remix of your teenage idols. Your moral compass might owe more to Samwise Gamgee or Avatar Aang than to any formal religion. The way you argue, flirt, grieve, celebrate, and hold space for others is likely borrowed—channeled—from characters you love, mentors you admire, gods you once prayed to in childhood without realizing you were praying.
+It's not something to feel guilty about. The appetite isn't the problem. The obedience is.
 
-At Purple, we come into contact with the deeply unoriginal nature of the Self. And rather than finding that disempowering, we begin to see the sacred in it.
+Free Will at Purple is not the freedom to chase every desire. It's the slow, unglamorous discovery that you are not required to obey them.
 
-Because here’s the thing: the Archetype Embodier doesn’t choose from nothing. They tune in. They receive. And then they selectively embody.
+And here is what the Hedonist can't see: the very sensitivity that hooks you—this open, porous, hungry receptivity—is the same faculty that lets you feel the truth of a myth in your chest, read meaning in a tarot card, receive an archetype and let it move through you. The Hedonist grasps. Integrated Purple receives.
 
-This is where Free Will is located in Purple—not in inventing from scratch, but in choosing which signals to amplify. Which stories to live. Which archetypes to breathe into your bones. It’s not so different from a musician picking which key to play in. You don’t make the key. But you resonate with it.
+Same wide-open channel. Opposite direction.
 
-This is what it means to have Receptive Free Will.
-You’re still steering, but you’re steering in a sea of voices. Some are divine. Some are projections. Some are wounds. Some are dreams. And if you develop discernment—the heart of Purple maturity—you can start to notice which ones are yours to carry.
+But we're getting ahead of ourselves. First you have to notice the thirst. Next time you catch yourself reaching—for the snack, the drink, the screen, the hit of being wanted—pause for one breath and ask: what am I actually thirsty for?
 
-So you get to ask: What am I channeling? Which gods walk through me? Which archetypes am I serving with my habits, my speech, my choices? Which scripts am I reading from without even realizing it?
-
-And more importantly: do they serve the version of me that I’m becoming?
-
-At Purple, you begin to answer those questions by slowing down, tuning in, and letting the symbolic self make itself known. Through tarot. Through synchronicity. Through journaling and dreaming and noticing what glimmers.
-
-Your job isn’t to force the world into shape. It’s to open your palms and ask: “What am I carrying? And is it mine?”
-
-From this receptive, mythically informed posture, Free Will becomes the art of embodiment. Of inviting in what is most true, and letting it move through you like wind through a flute.
-
-You are not the flute. You are not even the wind.
-
-You are the willingness.
+------------------------------------------------------------------------


### PR DESCRIPTION
## What this is

The rebuilt **Purple free-will section as "The Hedonist"** (#11), here as a clean diff against the current "Archetype Embodier" version so you can actually review it (it had only lived inline in chat).

Built to the Beige free-will template (`meta/BEIGE-TEMPLATE.md`), with the fixes PR #42 missed:
- **Short paragraphs** (1–3 sentences; single-sentence beats).
- **A teaching woven in** (the Buddha / taṇhā — craving as the root of suffering).
- **Sacral chakra** named (per the ratified map, #16).
- Voice matched to your Beige free-will section ("Let's get right to it…").

## The reframe (#11)

From the *aligned* "Archetype Embodier" (you're the vessel archetypes flow through) → the *first-pass/shadow* **Hedonist**, obsessed with slaking worldly desire. This completes the shadow progression the free-will sections already imply: **Beige = Biological Machine → Purple = Hedonist → Red = Dominator** (survive → slake → dominate). The old "receiving the archetypes" material is reclaimed as the *destination* ("The Hedonist grasps. Integrated Purple receives.").

## Two things to confirm

1. **Voice + the shadow→receiving arc** — does it land?
2. **"Purple is the Sacral chakra"** — keep or cut.

## Not done yet (queued for when you bless it)

- Rename `…-purple-archetype-embodier.md` → `…-purple-the-hedonist.md`
- Find/replace "Archetype Embodier" across Purple TOC + README + the alternative-practice file, and Red's back-reference.
- The rest of Purple's ~16 sections to the template, + #13 (realign the tarot practice to Purple's wavelength) — all bundled into the full Purple PR.
