### PR TITLE
Add "How the Wavelength works" as a site resource

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2538,6 +2538,13 @@
       "description": "From Liminal Creep to Whole Adept: who this course is for.",
       "media": [],
       "path": "markdown/resources/liminal-creep.md"
+    },
+    {
+      "slug": "wavelength-explainer",
+      "title": "How the Wavelength works",
+      "description": "A living picture of the Wavelength — torus, spiral, compression waves, rising octaves, and the chord of a single act.",
+      "media": [],
+      "path": "markdown/resources/wavelength-explainer.md"
     }
   ]
 }

--- a/markdown/resources/wavelength-explainer.md
+++ b/markdown/resources/wavelength-explainer.md
@@ -1,0 +1,67 @@
+---
+slug: wavelength-explainer
+title: "How the Wavelength works"
+content_type: essay
+description: "A living picture of the Wavelength — torus, spiral, compression waves, rising octaves, and the chord of a single act."
+media: []
+---
+
+This is a picture, not a measurement. Nothing here is a ladder to climb or a
+score to beat — it is simply a way of seeing the shape of a life as it turns.
+Read it slowly, and take only what resonates.
+
+## Your torus — the auric field
+
+Picture the field around you as a torus: a doughnut of energy that flows up
+through you, blooms out around you, and folds back in to rise again. It is the
+living shape of your presence — the vibration you are already emitting, moment
+to moment.
+
+The torus is art, not a test. Don't judge the art. A torus can be small and
+quiet or wide and luminous, and neither is a verdict on you. It simply is what
+it is right now, and it is always in motion.
+
+## The spiral that grows it
+
+Around that torus turns a spiral. Every honest pass through experience — every
+practice, every reflection, every ordinary day met with a little more presence
+— winds the spiral one more turn. As it turns, it grows the torus wider and
+lifts it, opening you toward the higher Stages of the arc.
+
+The spiral never retraces the same circle. It rises. What returns comes back
+around at a new turn, carrying everything the last turn taught you.
+
+## Compression waves — how you touch other souls
+
+Each Stage of the spiral emits vibration outward as compression waves — tiny
+toruses rippling off the larger one, the way a struck string sends its note
+into the air. These waves travel. A steadier presence, a kinder word, a settled
+room: these are compression waves, and they can gently raise the vibration of
+the souls they reach.
+
+You are always emitting. The Wavelength simply names what your presence is
+already doing in the field around you.
+
+## The rising octaves
+
+The wave itself moves through six phases in every cycle — Rising, Peaking,
+Withdrawal, Diminishing, Bottoming Out, and Restoration — and then it turns
+again. As the spiral lifts through the Stages of the arc, the same six-phase
+wave sounds again at a higher octave: the same music, pitched higher, richer in
+overtones. The rising octaves are those lifting Stages — each one the familiar
+cycle sung anew.
+
+An octave up is not "more worthy." It is the same song, wider in range. Every
+octave is whole in itself.
+
+## The chord
+
+A single action can sound from more than one Stage at once — a chord rather than
+a single note. You might act, in one breath, from the Integrative Stage and the
+Conformist Stage and from something rooted deep in plain survival, all at the
+same time. That is not confusion; it is fullness. A chord is richer than any
+one note alone.
+
+To hear your own chord — the many notes ringing together in a single act — is
+simply to know yourself more completely. That is all the Wavelength ever asks:
+that you listen.


### PR DESCRIPTION
Authors the "How the Wavelength works" explainer (torus, spiral, compression waves, rising octaves, and the chord of a single act) as a first-class site resource under `markdown/resources/wavelength-explainer.md`, and regenerates `manifest.json`.

The copy was previously a frontend-local data module in the Adepthood app; moving it here keeps the model copy canonical alongside the rest of the course content, so the app can serve it through the vendored content pipeline. Consistent with the six canonical Wavelength phases (Rising, Peaking, Withdrawal, Diminishing, Bottoming Out, Restoration).

Consumed by adepthood#1077.

## Test plan
- `python scripts/build_manifest.py --check` — manifest current + schema-valid
- `python scripts/check_links.py` — internal references resolve
- markdownlint-cli2 — 0 errors