### PR TITLE
docs: note app's proportional drip derivation (no schema change)

### DIFF
--- a/CONSUMPTION.md
+++ b/CONSUMPTION.md
@@ -70,6 +70,14 @@ update rather than render undefined behavior — which is why majors are
 coordinated, versioned, and shipped together with the app change
 (see §4 and CONTENT_FORMAT.md §8).
 
+**Not a version bump:** how the app *computes* lock/unlock state from the
+published fields is app-side behavior, not part of this contract. As of
+2026-07 the app derives a proportional drip schedule from `release_day`
+(ordering), chapter count, and its own app-owned stage duration, rather than
+gating solely on `release_day > days_elapsed` (see CONTENT_FORMAT.md §5.2).
+`release_day`'s authored value, type, and meaning are unchanged, so this
+shipped with **no** `schema_version` bump — it stayed at `1.1.0`.
+
 ---
 
 ## 3. Release tagging

--- a/CONTENT_FORMAT.md
+++ b/CONTENT_FORMAT.md
@@ -259,6 +259,19 @@ becomes available, mirroring today's drip-feed behavior
 `release_day` is **authored by a human** (issue #19), not derived — it encodes
 curricular intent, unlike `stage`/`chapter`/`order`/`slug` which are mechanical.
 
+> **App-side note (2026-07):** the app no longer gates purely on
+> `release_day > days_elapsed`. It derives a **proportional** drip —
+> `unlocked = ceil(chapter_count / stage_duration_days × day_in_stage)` — using
+> its own app-owned `stage_duration_days` (§4 is explicit that stage duration
+> is app territory, not authored here). This keeps a short stage from stalling
+> readers on a long calendar window and vice versa. `release_day` is still
+> authored per §5.2 and still used for **ordering** chapters within a stage
+> (and as the tiebreaker/fallback the app's lock check is built on); it is
+> simply no longer the *sole* unlock gate. This is an app-side (adepthood)
+> behavior change only — it requires no change to this repo's frontmatter,
+> `manifest.json`, or `schema_version` (still `1.1.0`), since `release_day`'s
+> authored value and meaning are unchanged.
+
 ---
 
 ## 6. Media & assets


### PR DESCRIPTION
adepthood now derives chapter unlock counts proportionally from chapter
count and its own app-owned stage duration instead of gating solely on
release_day > days_elapsed. Document this in CONTENT_FORMAT.md §5.2 and
CONSUMPTION.md so it's clear release_day retains its authored meaning
(ordering) and this required no manifest/schema_version bump.